### PR TITLE
fix(poly-notify): skip notifications in non-interactive mode (subagents)

### DIFF
--- a/extensions/poly-notify/notify.json.example
+++ b/extensions/poly-notify/notify.json.example
@@ -3,6 +3,7 @@
   "minDurationSeconds": 10,
   "sound": "silent",
   "showPopup": false,
+  "interactiveOnly": true,
   "sounds": [
     {
       "alias": "silent"


### PR DESCRIPTION
## Problem

When subagents run, they spawn separate `pi` processes in print mode (`-p --no-session`) that load the same extensions. poly-notify fires notifications (sound, popup, pushover) on `agent_end` in those subagent processes, causing spurious notifications every time a subagent completes.

## Solution

Add an `interactiveOnly` config option (default: `true`) that tracks `ctx.hasUI` from `session_start` and skips notifications when running in non-interactive mode.

- **`interactiveOnly: true`** (default) - notifications only fire in interactive sessions
- **`interactiveOnly: false`** - notifications fire everywhere, including subagents/print mode

## Changes

- `extensions/poly-notify/index.ts`: Add `interactiveOnly` to `NotifyConfig`, track `isInteractive` from `ctx.hasUI`, guard `agent_end` handler
- `extensions/poly-notify/notify.json.example`: Add the new option