### PR TITLE
fix: RepoPrompt 2.1 compatibility — tab discovery and new tool exemptions

### DIFF
--- a/extensions/repoprompt-mcp/src/binding.ts
+++ b/extensions/repoprompt-mcp/src/binding.ts
@@ -754,7 +754,7 @@ function parseTabFromJson(raw: unknown): RpTab | null {
   }
 
   const obj = raw as Record<string, unknown>;
-  const idRaw = obj.id ?? obj.tabId ?? obj.tab_id ?? obj.uuid;
+  const idRaw = obj.id ?? obj.tabId ?? obj.tab_id ?? obj.uuid ?? obj.context_id ?? obj.contextId;
   if (typeof idRaw !== "string" || !idRaw.trim()) {
     return null;
   }
@@ -839,8 +839,31 @@ function parseTabLine(line: string): RpTab | null {
     return null;
   }
 
+  if (/^[-•]\s*window\s+`\d+`/i.test(trimmed)) {
+    return null;
+  }
+
   if (!trimmed.includes("•") && !trimmed.toLowerCase().includes("tab")) {
     return null;
+  }
+
+  const contextIdLineMatch = trimmed.match(/^[-•]\s*(.+?)\s+[—-]\s*context_id:\s*`([^`]+)`\s*$/i);
+  if (contextIdLineMatch?.[1] && contextIdLineMatch[2]) {
+    const id = contextIdLineMatch[2].trim();
+    const name = stripTrailingTabStateAnnotations(contextIdLineMatch[1].trim()) || id;
+    const isActive = /\[(?:[^\]]*\bactive\b[^\]]*|[^\]]*\bin-focus\b[^\]]*)\]/i.test(trimmed)
+      ? true
+      : /\[[^\]]*\bout-of-focus\b[^\]]*\]/i.test(trimmed)
+        ? false
+        : undefined;
+    const isBound = /\[[^\]]*\bbound\b[^\]]*\]/i.test(trimmed) ? true : undefined;
+
+    return {
+      id,
+      name,
+      isActive,
+      isBound,
+    };
   }
 
   const idMatch = trimmed.match(/`([^`]+)`/);
@@ -1066,6 +1089,26 @@ export async function fetchWindowTabs(
     throw new Error("Not connected to RepoPrompt");
   }
 
+  const bindContextToolName = resolveToolName(client.tools, "bind_context");
+  if (bindContextToolName) {
+    const bindContextResult = await client.callTool(bindContextToolName, {
+      op: "list",
+      ...bindingWindowArgs(windowId),
+    });
+
+    if (!bindContextResult.isError) {
+      const tabsFromBindContextJson = parseTabsFromJson(extractJsonContent(bindContextResult.content));
+      if (tabsFromBindContextJson && tabsFromBindContextJson.length > 0) {
+        return tabsFromBindContextJson;
+      }
+
+      const tabsFromBindContextText = parseTabList(extractTextContent(bindContextResult.content));
+      if (tabsFromBindContextText.length > 0) {
+        return tabsFromBindContextText;
+      }
+    }
+  }
+
   const manageWorkspacesToolName = resolveToolName(client.tools, "manage_workspaces");
   if (!manageWorkspacesToolName) {
     return [];
@@ -1094,9 +1137,30 @@ async function selectTab(
   tabId: string,
   client: ReturnType<typeof getRpClient> = getRpClient()
 ): Promise<void> {
+  const bindContextToolName = resolveToolName(client.tools, "bind_context");
+  let bindContextError: string | null = null;
+
+  if (bindContextToolName) {
+    const bindResult = await client.callTool(bindContextToolName, {
+      op: "bind",
+      context_id: tabId,
+      ...bindingWindowArgs(windowId),
+    });
+
+    if (!bindResult.isError) {
+      return;
+    }
+
+    bindContextError = extractTextContent(bindResult.content) || `Failed to bind RepoPrompt tab ${tabId}`;
+  }
+
   const manageWorkspacesToolName = resolveToolName(client.tools, "manage_workspaces");
   if (!manageWorkspacesToolName) {
-    return;
+    if (bindContextError) {
+      throw new Error(bindContextError);
+    }
+
+    throw new Error("RepoPrompt tab binding is unavailable: neither bind_context nor manage_workspaces tool is available");
   }
 
   const result = await client.callTool(manageWorkspacesToolName, {
@@ -1108,7 +1172,7 @@ async function selectTab(
 
   if (result.isError) {
     const text = extractTextContent(result.content);
-    throw new Error(text || `Failed to bind RepoPrompt tab ${tabId}`);
+    throw new Error(text || bindContextError || `Failed to bind RepoPrompt tab ${tabId}`);
   }
 }
 

--- a/extensions/repoprompt-mcp/src/index.ts
+++ b/extensions/repoprompt-mcp/src/index.ts
@@ -2541,7 +2541,18 @@ Mode priority: call > describe > search > windows > bind > status`,
     const userArgs = (params.args ?? {}) as Record<string, unknown>;
     const normalizedTool = normalizeToolName(tool.name);
 
-    if (getBinding() && !getBinding()?.tab && normalizedTool !== "manage_workspaces" && normalizedTool !== "list_windows") {
+    if (
+      getBinding() &&
+      !getBinding()?.tab &&
+      normalizedTool !== "manage_workspaces" &&
+      normalizedTool !== "list_windows" &&
+      // bind_context can create/query tab bindings before a tab is set on the current binding
+      normalizedTool !== "bind_context" &&
+      // agent_run starts agent flows that may establish or recover tab state
+      normalizedTool !== "agent_run" &&
+      // agent_manage manages agent lifecycle/state and must remain available during tab recovery
+      normalizedTool !== "agent_manage"
+    ) {
       if (!ctx) {
         return {
           content: [{ type: "text" as const, text: "RepoPrompt binding has no tab. Re-bind with /rp bind before calling tab-scoped tools." }],


### PR DESCRIPTION
Fixes #8

## Summary

RepoPrompt 2.1.0 moved `list_tabs`/`select_tab` from `manage_workspaces` to the new `bind_context` tool, and added `agent_run`, `agent_manage`, `bind_context` tools that are blocked by the tab-scope guard.

## Changes

### `index.ts`
- Exempt `bind_context`, `agent_run`, `agent_manage` from the tab-scope guard (with explanatory comments)

### `binding.ts`
- **`fetchWindowTabs()`**: try `bind_context op="list"` first, fall back to `manage_workspaces list_tabs` for older RP versions. Only short-circuits when at least one tab is parsed — falls through to legacy path on empty results.
- **`selectTab()`**: try `bind_context op="bind" context_id=...` first, fall back to `manage_workspaces select_tab`. Throws if neither mechanism is available (previously returned silently).
- **`parseTabFromJson()`**: accepts `context_id`/`contextId` as tab ID fields
- **`parseTabLine()`**: parses `bind_context list` output format (`• TabName [active] — context_id: \`UUID\``), skips window header lines with tightened regex (`Window \`<number>\``)

## Backward compatibility

All changes use a try-first/fallback pattern — `bind_context` is preferred when available (RP 2.1+), with graceful fallback to `manage_workspaces` for older versions. Tool availability is checked via `resolveToolName()` before each call.

## Tested

- Verified tab auto-provisioning works on startup (no more "failed to provision a safe tab" warnings)
- Regular tools (`read_file`, `file_search`, etc.) work without "binding has no tab" errors
- `agent_run`, `agent_manage`, `bind_context` all callable without a pre-existing tab binding
- Existing test suite passes (97/97)