### PR TITLE
refactor: Update references to RepoPrompt CE tooling

### DIFF
--- a/AGENTS-prefaces/README.md
+++ b/AGENTS-prefaces/README.md
@@ -1,15 +1,15 @@
 # AGENTS Prefaces
 
-Templates for the start of `AGENTS.md` or `CLAUDE.md` files. These steer agents to use RepoPrompt tools preferentially and effectively.
+Templates for the start of `AGENTS.md` or `CLAUDE.md` files. These steer agents to use RepoPrompt CE tools preferentially and effectively.
 
 ## Files
 
-- `rp-mcp-preface.md` — RepoPrompt MCP integration (`rp` tool)
-- `rp-mcp-preface-exPi.md` — MCP variant for non-Pi harnesses (Claude Code, Codex, etc.)
-- `rp-cli-preface.md` — RepoPrompt CLI integration (deprecated)
+- `rp-mcp-preface.md` - RepoPrompt CE MCP integration (`rp` tool)
+- `rp-mcp-preface-exPi.md` - RepoPrompt CE MCP variant for non-Pi harnesses (Claude Code, Codex, etc.)
+- `rp-classic-cli-preface.md` - RepoPrompt Classic Edition CLI integration (deprecated)
 
 ## Notes
 
 The exPi variant is intended for other agent harnesses and omits Pi-specific features.
 
-The other variants include a section advising usage of the `session_ask` and `session_lineage` tools, which are unrelated to RepoPrompt but are offered in this repo.  They also include a section advising usage of the `web_search` and `fetch_content` tools, which are not included in this repo but can be installed via `pi install npm:pi-web-access` (see [nicobailon/pi-web-access](https://github.com/nicobailon/pi-web-access)).
+The other variants include a section advising usage of the `session_ask` and `session_lineage` tools, which are unrelated to RepoPrompt CE but are offered in this repo.  They also include a section advising usage of the `web_search` and `fetch_content` tools, which are not included in this repo but can be installed via `pi install npm:pi-web-access` (see [nicobailon/pi-web-access](https://github.com/nicobailon/pi-web-access)).

--- a/AGENTS-prefaces/rp-classic-cli-preface.md
+++ b/AGENTS-prefaces/rp-classic-cli-preface.md
@@ -1,4 +1,4 @@
-> **⚠ This AGENTS.md preface is for the deprecated `repoprompt-cli` extension.**  Consider instead to use [`repoprompt-mcp`](../extensions/repoprompt-mcp/) and its recommended AGENTS.md [preface](rp-mcp-preface.md) instead.
+> **⚠ This AGENTS.md preface is for the deprecated RepoPrompt Classic Edition `repoprompt-cli` extension.**  Consider instead to use [`repoprompt-mcp`](../extensions/repoprompt-mcp/) and its recommended AGENTS.md [preface](rp-mcp-preface.md) instead.
 
 ---
 
@@ -6,19 +6,19 @@
 
 The following instructions **override** generic tool guidance for **repo exploration, context building, and file editing** inside Pi.
 
-RepoPrompt (via `rp_exec`) is the default for repo-scoped work because it materially improves context quality and reduces routing mistakes.
+RepoPrompt Classic Edition (via `rp_exec`) is the default for repo-scoped work because it materially improves context quality and reduces routing mistakes.
 
 Backticked snippets in this doc are either an `rp_exec.cmd` string (what goes after `rp-cli -e`) or a full `rp-cli ...` shell command (explicitly prefixed with `rp-cli`). Pi native tools are explicitly labeled.
 
 ## Note on native tool disablement (rp-tools-lock)
 
-Native repo-file tools (`read/write/edit/ls/find/grep`) may be disabled automatically when RepoPrompt is available. If a native tool call is blocked, use the RepoPrompt equivalents (`rp_exec` / `rp-cli`). Disable with `/rp-tools-lock off` only if you explicitly need the native tools.
+Native repo-file tools (`read/write/edit/ls/find/grep`) may be disabled automatically when RepoPrompt Classic Edition is available. If a native tool call is blocked, use the RepoPrompt Classic Edition equivalents (`rp_exec` / `rp-cli`). Disable with `/rp-tools-lock off` only if you explicitly need the native tools.
 
 ---
 
 ## Mental Model
 
-RepoPrompt (macOS app) organizes state as:
+RepoPrompt Classic Edition (macOS app) organizes state as:
 - **Workspaces** → one or more root folders
 - **Windows** → each shows one workspace
 - **Compose tabs / contexts** → each tab has a prompt + file selection (selection is what Oracle/review sees)
@@ -51,7 +51,7 @@ If output looks wrong (0 matches / wrong files / empty results), check routing f
 
 Do not use bash for: `ls`, `find`, `grep`, `cat`, `wc`, `tree`, or similar file exploration.
 
-Prefer `rp_exec` / `rp-cli` for repo-scoped work. The native repo-file tools (`read/write/edit/ls/find/grep`) may be disabled automatically when RepoPrompt is available.
+Prefer `rp_exec` / `rp-cli` for repo-scoped work. The native repo-file tools (`read/write/edit/ls/find/grep`) may be disabled automatically when RepoPrompt Classic Edition is available.
 
 Never switch workspaces in an existing window unless the user explicitly says it's safe. Switching clobbers selection, prompt, and context. Prefer `workspace switch <name> --new-window`.
 
@@ -92,7 +92,7 @@ Each rp_exec call is a fresh connection. Use `&&` to chain deterministic sequenc
 | Code editing (fallback) | pi native `edit` | use when direct rp-cli call mode isn't available |
 | File create/move/delete | rp_exec `file create/move/delete` | workspace-aware |
 | File creation with content | `rp-cli -w <id> -t <context_id> -c file_actions -j '{...}'` | JSON args required; `path` / `new_path` must be absolute |
-| App settings | `rp-cli -w <id> -t <context_id> -c app_settings -j '{...}'` | query/update allowlisted RepoPrompt app preferences |
+| App settings | `rp-cli -w <id> -t <context_id> -c app_settings -j '{...}'` | query/update allowlisted RepoPrompt Classic Edition app preferences |
 
 ---
 
@@ -103,7 +103,7 @@ If a relative path could match multiple loaded roots, use `RootName:rel/path`.
 
 Notes:
 - `search`/`file_search path="..."` is an alias for `search`/`file_search filter.paths=["..."]`
-- `search`/`file_search filter.paths` accepts paths *or* a loaded root name (e.g. `"RepoPrompt"`)
+- `search`/`file_search filter.paths` accepts paths *or* a loaded root name (e.g. `"RepoPrompt Classic Edition"`)
 - `file_actions` in call mode is stricter than most RP tools: `path` / `new_path` must be absolute
 - `structure`/`get_code_structure` line numbers match `read`/`read_file` and refresh after edits
 
@@ -116,7 +116,7 @@ Notes:
 - Tail read via negative start: `read path/to/file -20` (last 20 lines)
 
 ### Edge case: files containing ``` fences
-RepoPrompt output is fenced; rare collision if the file itself contains ``` lines. Workaround: use `rawJson=true` and call `read_file` directly: `read_file path=path/to/file start_line=1 limit=160`
+RepoPrompt Classic Edition output is fenced; rare collision if the file itself contains ``` lines. Workaround: use `rawJson=true` and call `read_file` directly: `read_file path=path/to/file start_line=1 limit=160`
 
 ### Readcache
 
@@ -165,7 +165,7 @@ If you need to create a file with full content in one step, call `file_actions` 
 
 ### App settings
 
-Use `app_settings` in call mode for allowlisted app-wide RepoPrompt preferences. `get` accepts exactly one of `key`, `keys`, or `group`; `set` and `options` take one `key`.
+Use `app_settings` in call mode for allowlisted app-wide RepoPrompt Classic Edition preferences. `get` accepts exactly one of `key`, `keys`, or `group`; `set` and `options` take one `key`.
 
 Example:
 `rp-cli -w <id> -t <context_id> -c app_settings -j '{"op":"options","key":"models.planning_model","agent":"codexExec"}'`
@@ -181,7 +181,7 @@ If results look wrong:
 3. `tabs list` if needed, then bind to the correct context
 4. Don't "fix" confusion by switching workspaces in-place
 
-RepoPrompt only operates within workspace root folders. If the repo isn't in any workspace:
+RepoPrompt Classic Edition only operates within workspace root folders. If the repo isn't in any workspace:
 
 ```
 workspace create Temp --folder-path /abs/path --new-window
@@ -236,7 +236,7 @@ For applying code changes, pi native `edit` is an acceptable fallback when rp-cl
 3) Apply changes iteratively (see **Editing** section) and re-run `context` after meaningful changes
 
 ### [SECOND OPINION] (complex / risky changes)
-Use RepoPrompt Oracle as a reviewer (not an executor):
+Use RepoPrompt Classic Edition Oracle as a reviewer (not an executor):
 `plan "Review my approach for … and call out risks"`
 
 ---

--- a/AGENTS-prefaces/rp-mcp-preface-exPi.md
+++ b/AGENTS-prefaces/rp-mcp-preface-exPi.md
@@ -2,13 +2,13 @@
 
 The following instructions **override** generic tool guidance for **repo exploration, context building, and file editing**.
 
-RepoPrompt MCP tools are the default for repo-scoped work because they materially improve context quality and reduce routing mistakes.
+RepoPrompt CE MCP tools are the default for repo-scoped work because they materially improve context quality and reduce routing mistakes.
 
 ---
 
 ## Mental Model
 
-RepoPrompt (macOS app) organizes state as:
+RepoPrompt CE (macOS app) organizes state as:
 - **Workspaces** → one or more root folders
 - **Windows** → each shows one workspace
 - **Compose tabs** → each tab has a prompt + file selection (selection is what oracle/review sees)
@@ -21,9 +21,9 @@ MCP tools operate directly against this state.
 
 ---
 
-## Why RepoPrompt Tools Are Default
+## Why RepoPrompt CE Tools Are Default
 
-Use RepoPrompt MCP tools over native tools for repo work because they improve context quality:
+Use RepoPrompt CE MCP tools over native tools for repo work because they improve context quality:
 
 - **Better exploration primitives**: `get_file_tree`, `file_search`, and `get_code_structure` are gitignore-aware and tuned for codebase navigation
 - **Selection = context**: the compose tab's selection is the single source of truth for what `oracle_send` sees
@@ -36,7 +36,7 @@ You're optimizing for **correctness and stable context**, not convenience.
 
 ## Workspace Hygiene (Session Start Priority)
 
-When a task involves a repository that isn't loaded in any existing RepoPrompt window:
+When a task involves a repository that isn't loaded in any existing RepoPrompt CE window:
 
 1. **Do NOT** use `manage_workspaces action="add_folder"` to add unrelated repositories to an existing workspace
 2. **Instead**, either:
@@ -74,12 +74,12 @@ Keep context intentional: select only what you need, prefer codemaps for referen
 | File ops | `file_actions action="create\|move\|delete" path="..."` | absolute paths only for `path` / `new_path` |
 | Planning/review | `oracle_send mode="chat\|plan\|edit\|review" [new_chat=true] [chat_id="..."] [export_response=true]` | current selection is the input context; exporting returns `oracle_export_path` + `oracle_export_instruction` |
 | Oracle helpers | `oracle_utils op="models\|sessions" [limit=N] [context_id="..."] [scope="workspace\|tab"]` | list models or existing Oracle conversations; `sessions` defaults to the current workspace and can filter to a specific context |
-| Sticky routing | `bind_context op="status\|bind\|list" [context_id="..."] [working_dirs="/abs/root[,/abs/root2]"]` | use `list` to discover windows and `context_id`s; prefer `bind context_id="..."` to pin a tab, or use `working_dirs` when you want RepoPrompt to route to a workspace by roots (exact match first, repo_paths superset fallback) |
+| Sticky routing | `bind_context op="status\|bind\|list" [context_id="..."] [working_dirs="/abs/root[,/abs/root2]"]` | use `list` to discover windows and `context_id`s; prefer `bind context_id="..."` to pin a tab, or use `working_dirs` when you want RepoPrompt CE to route to a workspace by roots (exact match first, repo_paths superset fallback) |
 | Workspace inventory/tab lifecycle | `manage_workspaces action="list\|switch\|create\|delete\|add_folder\|remove_folder\|create_tab\|close_tab"` | inventory + lifecycle only; use `bind_context` for routing |
 | Auto context | `context_builder instructions="..." [response_type="clarify\|question\|plan\|review"]` | token-costly, invoke explicitly |
 | Agent runs | `agent_run op="start\|poll\|wait\|cancel\|steer\|respond"` | advanced, session-based Agent Mode control; `poll`/`wait` accept `session_id` or `session_ids` |
 | Agent/session management | `agent_manage op="list_agents\|list_sessions\|get_log\|create_session\|resume_session\|stop_session\|cleanup_sessions\|list_workflows" [roles_only=true]` | inspect durable session/workflow state; `roles_only=true` with `list_agents` returns just the role labels (explore, engineer, pair, design) and their default models |
-| App settings | `app_settings op="list\|get\|set\|options" [group="..."] [key="..."]` | read/update allowlisted RepoPrompt app-wide preferences |
+| App settings | `app_settings op="list\|get\|set\|options" [group="..."] [key="..."]` | read/update allowlisted RepoPrompt CE app-wide preferences |
 | Git operations | `git op="status\|diff\|log\|show\|blame" [compare="..."] [detail="..."]` | detail levels: `summary\|files\|patches\|full`; worktree support via `main`/`trunk` aliases and merge-base comparisons, `@main:<branch>` |
 
 ---
@@ -101,20 +101,20 @@ If results look wrong, assume routing first—not tool failure.
 
 1. `bind_context op="list"` — inspect windows, active workspaces, tabs, `context_id`s, and current bindings when you need to disambiguate
 2. Prefer `bind_context op="bind" context_id="..."` — pin the specific compose context you want after choosing it from `list`
-3. Use `bind_context op="bind" working_dirs="/abs/root"` when you want RepoPrompt to route to a workspace by roots without pinning a tab
+3. Use `bind_context op="bind" working_dirs="/abs/root"` when you want RepoPrompt CE to route to a workspace by roots without pinning a tab
 4. `get_file_tree` — confirm workspace roots
 
 Notes:
 - `bind_context.list` is the per-window routing view
 - `manage_workspaces.list` is the workspace inventory
 - `bind_context op="bind" working_dirs="/abs/root[,/abs/root2]"` matches workspace roots, not descendant paths
-- Matching prefers an exact workspace `repo_paths` set; if none exists, RepoPrompt may fall back to a workspace whose roots are a strict superset
+- Matching prefers an exact workspace `repo_paths` set; if none exists, RepoPrompt CE may fall back to a workspace whose roots are a strict superset
 
-RepoPrompt only operates within workspace root folders.
+RepoPrompt CE only operates within workspace root folders.
 
 ## Agent Mode
 
-`agent_run` + `agent_manage` are RepoPrompt's external control plane for Agent Mode: use them when you need to drive a long-running per-tab subagent session, not just make one-off MCP file/chat calls.
+`agent_run` + `agent_manage` are RepoPrompt CE's external control plane for Agent Mode: use them when you need to drive a long-running per-tab subagent session, not just make one-off MCP file/chat calls.
 
 - Use `agent_run` for run lifecycle: `start`, `wait`/`poll`, `respond`, `steer`, `cancel`; `start` defaults to `pair` when `model_id` is omitted
 - Use `agent_manage` for durable metadata: discover agents/workflows, list sessions, read transcripts
@@ -154,7 +154,7 @@ RepoPrompt only operates within workspace root folders.
 
 ### [SECOND OPINION] (complex/risky changes)
 
-Use RepoPrompt Oracle as reviewer:
+Use RepoPrompt CE Oracle as reviewer:
 `oracle_send mode="plan" message="Review my approach for ... and call out risks" new_chat=true`
 
 ---
@@ -186,19 +186,19 @@ Token-costly—invoke explicitly when user requests or during planning phases, n
 
 `app_settings op="list|get|set|options" ...`
 
-Use this for allowlisted app-wide RepoPrompt preferences. `get` accepts exactly one of `key`, `keys`, or `group`; `set` and `options` take one `key`. Current groups: `ui`, `prompt_packaging`, `models`, `context_builder`, `mcp`, `code_maps`, `file_system`, `agent_mode`.
+Use this for allowlisted app-wide RepoPrompt CE preferences. `get` accepts exactly one of `key`, `keys`, or `group`; `set` and `options` take one `key`. Current groups: `ui`, `prompt_packaging`, `models`, `context_builder`, `mcp`, `code_maps`, `file_system`, `agent_mode`.
 
 ---
 
 ## Start Here
 
-When the task involves a repository, RepoPrompt is your toolkit for exploration, reading, editing, and file operations.
+When the task involves a repository, RepoPrompt CE is your toolkit for exploration, reading, editing, and file operations.
 
 1. `bind_context op="status"`
 2. If needed, `bind_context op="list"`, then `bind_context op="bind" context_id="..."`
 3. Then use `get_file_tree`, `file_search`, `read_file`, `apply_edits`
 
-Use native tools only when RepoPrompt is unavailable after one retry.
+Use native tools only when RepoPrompt CE is unavailable after one retry.
 
 Unexpected output is usually a routing issue—wrong workspace, wrong window, wrong tab—not a tool failure. Check routing before falling back.
 

--- a/AGENTS-prefaces/rp-mcp-preface.md
+++ b/AGENTS-prefaces/rp-mcp-preface.md
@@ -1,16 +1,16 @@
 # Tool Protocol
 
-## Your Default Tools Are RepoPrompt (`rp`)
+## Your Default Tools Are RepoPrompt CE (`rp`)
 
 These instructions **override** generic tool guidance for **repo exploration, context building, and file editing** inside Pi.
 
-RepoPrompt MCP is the default for repo-scoped work. Use `rp`:
+RepoPrompt CE MCP is the default for repo-scoped work. Use `rp`:
 - **Bind**: `rp({ windows: true })` → `rp({ bind: { window: N } })`
 - **Call tools**: `rp({ call: "<tool>", args: { ... } })` (unless explicitly labeled as a Pi native tool)
 
 ### Mental Model
 
-RepoPrompt (macOS app) organizes state as:
+RepoPrompt CE (macOS app) organizes state as:
 - **Workspaces** → one or more root folders
 - **Windows** → each shows one workspace
 - **Tabs** → each tab has its own prompt + file selection; selections, slices, and codemaps are tab-scoped
@@ -22,7 +22,7 @@ MCP tools operate directly against this state, but in Pi you invoke them through
 
 ### Workspace Hygiene (Session Start Priority)
 
-When a task involves a repository that isn't loaded in any existing RepoPrompt window:
+When a task involves a repository that isn't loaded in any existing RepoPrompt CE window:
 
 1. **Do NOT** use `manage_workspaces action="add_folder"` to add unrelated repositories to an existing workspace
 2. **Instead**, either:
@@ -36,7 +36,7 @@ Rationale: Keep workspaces coherent; mixing unrelated repos clutters selection a
 
 Do not use bash for: `ls`, `find`, `grep`, `cat`, `wc`, `tree`, or similar file exploration.
 
-Prefer RepoPrompt MCP tools for repo-scoped work. The native repo-file tools (`read/write/edit/ls/find/grep`) may be disabled automatically when RepoPrompt is available.
+Prefer RepoPrompt CE MCP tools for repo-scoped work. The native repo-file tools (`read/write/edit/ls/find/grep`) may be disabled automatically when RepoPrompt CE is available.
 
 Never switch workspaces in an existing window unless the user explicitly says it's safe. Switching clobbers selection, prompt, and context. Use `open_in_new_window=true`.
 
@@ -56,13 +56,13 @@ Keep context intentional: select only what you need, prefer codemaps for referen
 | File ops | `file_actions action="create\|move\|delete" path="..."` | absolute paths only for `path` / `new_path` |
 | Planning/review | `oracle_send mode="chat\|plan\|edit\|review" [new_chat=true] [chat_id="..."] [export_response=true]` | uses the current tab/context; exporting returns `oracle_export_path` + `oracle_export_instruction` |
 | Oracle helpers | `oracle_utils op="models\|sessions" [limit=N] [context_id="..."] [scope="workspace\|tab"]` | list models or existing Oracle conversations; `sessions` defaults to the current workspace and can filter to a specific context |
-| Sticky routing | `bind_context op="status\|bind\|list" [context_id="..."] [working_dirs="/abs/root[,/abs/root2]"]` | use `list` to discover windows and `context_id`s; prefer `bind context_id="..."` to pin a tab, or use `working_dirs` when you want RepoPrompt to route to a workspace by roots (exact match first, repo_paths superset fallback) |
+| Sticky routing | `bind_context op="status\|bind\|list" [context_id="..."] [working_dirs="/abs/root[,/abs/root2]"]` | use `list` to discover windows and `context_id`s; prefer `bind context_id="..."` to pin a tab, or use `working_dirs` when you want RepoPrompt CE to route to a workspace by roots (exact match first, repo_paths superset fallback) |
 | Window routing bootstrap | `rp({ windows: true })` then `rp({ bind: { window: N } })` | only for initial window selection before using `bind_context` |
 | Workspace inventory/tab lifecycle | `manage_workspaces action="list\|switch\|create\|delete\|add_folder\|remove_folder\|create_tab\|close_tab"` | inventory + lifecycle only; use `bind_context` for routing/context discovery |
 | Agent runs | `agent_run op="start\|poll\|wait\|cancel\|steer\|respond"` | advanced, session-based Agent Mode control; `poll`/`wait` accept `session_id` or `session_ids` |
 | Agent/session management | `agent_manage op="list_agents\|list_sessions\|get_log\|create_session\|resume_session\|stop_session\|cleanup_sessions\|list_workflows" [roles_only=true]` | inspect durable session/workflow state; `roles_only=true` with `list_agents` returns just the role labels (explore, engineer, pair, design) and their default models |
 | Auto context | `context_builder instructions="..." [response_type="clarify\|question\|plan\|review"]` | token-costly, invoke explicitly |
-| App settings | `app_settings op="list\|get\|set\|options" [group="..."] [key="..."]` | read/update allowlisted RepoPrompt app-wide preferences |
+| App settings | `app_settings op="list\|get\|set\|options" [group="..."] [key="..."]` | read/update allowlisted RepoPrompt CE app-wide preferences |
 | Git operations | `git op="status\|diff\|log\|show\|blame" [compare="..."] [detail="..."]` | worktree support via `main`/`trunk` aliases and merge-base comparisons, `@main:<branch>` |
 
 ### Paths and roots
@@ -85,19 +85,19 @@ If results look wrong, assume routing first—not tool failure.
 3. Otherwise `rp({ bind: { window: N } })` — bind to the right window
 4. `bind_context op="list"` — inspect windows, active workspaces, tabs, `context_id`s, and current bindings when routing is ambiguous
 5. Prefer `bind_context op="bind" context_id="..."` — pin the specific compose tab you want after choosing it from `list`
-6. Use `bind_context op="bind" working_dirs="/abs/root"` when you want RepoPrompt to route to a workspace by roots without pinning a tab
+6. Use `bind_context op="bind" working_dirs="/abs/root"` when you want RepoPrompt CE to route to a workspace by roots without pinning a tab
 7. `get_file_tree` — confirm workspace roots
 
 Notes:
 - `bind_context op="bind" working_dirs="/abs/root[,/abs/root2]"` matches workspace roots, not descendant paths
-- Matching prefers an exact workspace `repo_paths` set; if none exists, RepoPrompt may fall back to a workspace whose roots are a strict superset
+- Matching prefers an exact workspace `repo_paths` set; if none exists, RepoPrompt CE may fall back to a workspace whose roots are a strict superset
 - `manage_workspaces action="list"` is the workspace inventory; `bind_context op="list"` is the routing view
 
-RepoPrompt only operates within workspace root folders.
+RepoPrompt CE only operates within workspace root folders.
 
 ### Agent Mode
 
-`agent_run` + `agent_manage` are RepoPrompt's external control plane for Agent Mode: use them when you need to drive a long-running per-tab subagent session, not just make one-off MCP file/chat calls.
+`agent_run` + `agent_manage` are RepoPrompt CE's external control plane for Agent Mode: use them when you need to drive a long-running per-tab subagent session, not just make one-off MCP file/chat calls.
 
 - Use `agent_run` for run lifecycle: `start`, `wait`/`poll`, `respond`, `steer`, `cancel`; `start` defaults to `pair` when `model_id` is omitted
 - Use `agent_manage` for durable metadata: discover agents/workflows, list sessions, read transcripts
@@ -130,7 +130,7 @@ Token-costly—invoke explicitly when user requests or during planning phases, n
 
 `app_settings op="list|get|set|options" ...`
 
-Use this for allowlisted app-wide RepoPrompt preferences. `get` accepts exactly one of `key`, `keys`, or `group`; `set` and `options` take one `key`. Current groups: `ui`, `prompt_packaging`, `models`, `context_builder`, `mcp`, `code_maps`, `file_system`, `agent_mode`.
+Use this for allowlisted app-wide RepoPrompt CE preferences. `get` accepts exactly one of `key`, `keys`, or `group`; `set` and `options` take one `key`. Current groups: `ui`, `prompt_packaging`, `models`, `context_builder`, `mcp`, `code_maps`, `file_system`, `agent_mode`.
 
 ### Edit Discipline
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .π
 
-Extensions, skills, prompts, and themes for the [Pi coding agent](https://github.com/badlogic/pi-mono).  Several of the extensions and prompts are designed to facilitate integration of Pi and [RepoPrompt](https://repoprompt.com/docs#s=overview).
+Extensions, skills, prompts, and themes for the [Pi coding agent](https://github.com/badlogic/pi-mono).  Several of the extensions and prompts are designed to facilitate integration of Pi and [RepoPrompt CE](https://repoprompt.com/docs#s=overview). Older commits in the repository have files for RepoPrompt Classic Edition, which is no longer supported.
 
 This collection is tailored to my workflow and preferences.  I may introduce breaking changes without notice.  While most of the extensions are original or modified, some that were authored by others are republished here unmodified, and those may lag well behind their upstream versions.  Extensions published as [Pi packages](#install-individual-extensions-from-npm) receive my active maintenance.
 
@@ -107,7 +107,7 @@ See [extensions/README.md](extensions/README.md) for more detailed descriptions.
 | ● | `command-center/` | [`pi-command-center`](https://www.npmjs.com/package/pi-command-center) | `/command` palette widget |
 | ◐ | `editor-enhancements/` | | File picker, shell completions, raw paste, double-esc and slash command remapping |
 | ● | `ephemeral-mode.ts` | [`pi-ephemeral`](https://www.npmjs.com/package/pi-ephemeral) | Delete session on exit |
-| ◐ | `files-touched.ts` | | Files read/modified/ widget with path normalization and tracking coverage of Pi-native tools, RepoPrompt, and bash |
+| ◐ | `files-touched.ts` | | Files read/modified/ widget with path normalization and tracking coverage of Pi-native tools, RepoPrompt CE, and bash |
 | ● | `fork-from-first.ts` | [`pi-fork-from-first`](https://www.npmjs.com/package/pi-fork-from-first) | Quickly fork session from first message to establish parent-child lineage in a blank new session |
 | ● | `grounded-compaction/` | [`pi-grounded-compaction`](https://www.npmjs.com/package/pi-grounded-compaction) | Compaction summarizer with model presets, custom prompts, and files-touched tracking |
 | ◐ | `handover/` | | Handover draft with files-touched → fork-from-first → prefill editor |
@@ -117,10 +117,10 @@ See [extensions/README.md](extensions/README.md) for more detailed descriptions.
 | ● | `model-sysprompt-appendix/` | [`pi-model-sysprompt-appendix`](https://www.npmjs.com/package/pi-model-sysprompt-appendix) | Per-model system prompt additions |
 | ● | `move-session.ts` | [`pi-move-session`](https://www.npmjs.com/package/pi-move-session) | Move current active session to a new cwd |
 | ◐ | `oracle.ts` | | Second opinion from alternate model |
-| ◐ | `plan-mode.ts` | [`pi-plan-modus`](https://www.npmjs.com/package/pi-plan-modus) | Read-only planning sandbox with RepoPrompt support |
+| ◐ | `plan-mode.ts` | [`pi-plan-modus`](https://www.npmjs.com/package/pi-plan-modus) | Read-only planning sandbox with RepoPrompt CE support |
 | ● | `poly-notify/` | [`pi-poly-notify`](https://www.npmjs.com/package/pi-poly-notify) | Desktop / sound / Pushover notifications |
 | ● | `protect-paths.ts` | | Directory protection, brew prevention, command gates. 🔄 Pair with [`@aliou/pi-guardrails`](https://github.com/aliou/pi-guardrails) for `.env` + AST gates |
-| ● | `repoprompt-mcp/` | [`pi-repoprompt-mcp`](https://www.npmjs.com/package/pi-repoprompt-mcp) | RepoPrompt MCP proxy with adaptive diff rendering, collapsed outputs, read-cache, and branch-safe binding |
+| ● | `repoprompt-mcp/` | [`pi-repoprompt-mcp`](https://www.npmjs.com/package/pi-repoprompt-mcp) | RepoPrompt CE MCP proxy with adaptive diff rendering, collapsed outputs, read-cache, and branch-safe binding |
 | ● | `reverse-thinking.ts` | | Backward thinking-level cycling on `shift+alt+tab` |
 | ● | `roam/` | [`pi-roam`](https://www.npmjs.com/package/pi-roam) | Post-hoc tmux handoff for remote continuation of sessions |
 | ● | `rp-native-tools-lock/` | [`pi-repoprompt-tools-lock`](https://www.npmjs.com/package/pi-repoprompt-tools-lock) | Prefer RP tools over Pi native tools |
@@ -212,7 +212,7 @@ See [prompts/README.md](prompts/README.md) for full descriptions.
 | ● | `rp-plan.md` |
 | ● | `rp-review-chat.md` |
 
-**AGENTS.md prefaces for reliable RepoPrompt tool usage** — see [AGENTS-prefaces/README.md](AGENTS-prefaces/README.md)
+**AGENTS.md prefaces for reliable RepoPrompt CE tool usage** — see [AGENTS-prefaces/README.md](AGENTS-prefaces/README.md)
 
 | | Preface |
 |---|---|

--- a/extensions/plan-mode.ts
+++ b/extensions/plan-mode.ts
@@ -3,15 +3,15 @@
  *
  * Provides a Claude Code-style "plan mode" read-only sandbox for safe code exploration.
  * When enabled, Pi-native write tools are removed from the active Pi tool list and
- * write-capable bash/RepoPrompt operations are blocked.
+ * write-capable bash/RepoPrompt CE operations are blocked.
  *
  * Features:
  * - /plan command (and Ctrl+Alt/Option+P shortcut) to toggle plan mode
  * - --plan flag to start in plan mode
  * - Removes Pi-native write tools (`edit`, `write`) from the active Pi tool list while enabled
  * - Blocks destructive bash commands while plan mode is enabled (including redirects)
- * - Blocks RepoPrompt write commands (edit/file/file_actions/apply-edits), even via bash rp-cli -e, rp_exec, or rp (repoprompt-mcp)
- * - Blocks rp-cli interactive REPL (-i/--interactive) to prevent bypassing the sandbox
+ * - Blocks RepoPrompt CE write commands (edit/file/file_actions/apply-edits), even via bash rp-cli -e, rp_exec, or rp (repoprompt-mcp)
+ * - Blocks rpce-cli (previously rp-cli in Repo Prompt Classic Edition) interactive REPL (-i/--interactive) to prevent bypassing the sandbox
  * - Adds plan-mode instructions via the system prompt only while plan mode is enabled
  * - Shows a "plan" indicator in the status line when active
  * - Persists plan mode state only when toggled (and once at startup if --plan is used)
@@ -352,59 +352,60 @@ const DESTRUCTIVE_PATTERNS = [
 
 // Read-only commands that are always safe
 const SAFE_COMMANDS = [
-	/^\s*cat\b/,
-	/^\s*head\b/,
-	/^\s*tail\b/,
-	/^\s*less\b/,
-	/^\s*more\b/,
-	/^\s*grep\b/,
-	/^\s*find\b/,
-	/^\s*ls\b/,
-	/^\s*pwd\b/,
-	/^\s*echo\b/,
-	/^\s*printf\b/,
-	/^\s*wc\b/,
-	/^\s*sort\b/,
-	/^\s*uniq\b/,
-	/^\s*diff\b/,
-	/^\s*file\b/,
-	/^\s*stat\b/,
-	/^\s*du\b/,
-	/^\s*df\b/,
-	/^\s*tree\b/,
-	/^\s*which\b/,
-	/^\s*whereis\b/,
-	/^\s*type\b/,
-	/^\s*env\b/,
-	/^\s*printenv\b/,
-	/^\s*uname\b/,
-	/^\s*whoami\b/,
-	/^\s*id\b/,
-	/^\s*date\b/,
-	/^\s*cal\b/,
-	/^\s*uptime\b/,
-	/^\s*ps\b/,
-	/^\s*top\b/,
-	/^\s*htop\b/,
-	/^\s*free\b/,
-	/^\s*git\s+(status|log|diff|show|branch|remote|config\s+--get)/i,
-	/^\s*git\s+ls-/i,
-	/^\s*npm\s+(list|ls|view|info|search|outdated|audit)/i,
-	/^\s*yarn\s+(list|info|why|audit)/i,
-	/^\s*node\s+--version/i,
-	/^\s*python\s+--version/i,
-	/^\s*curl\s/i,
-	/^\s*wget\s+-O\s*-/i,
-	/^\s*jq\b/,
-	/^\s*sed\s+-n/i,
-	/^\s*awk\b/,
-	/^\s*rg\b/,
-	/^\s*fd\b/,
-	/^\s*bat\b/,
-	/^\s*exa\b/,
-	/^\s*rp-cli\b/,
-	/^\s*rp_exec\b/,
-	/^\s*rp_bind\b/,
+  /^\s*cat\b/,
+  /^\s*head\b/,
+  /^\s*tail\b/,
+  /^\s*less\b/,
+  /^\s*more\b/,
+  /^\s*grep\b/,
+  /^\s*find\b/,
+  /^\s*ls\b/,
+  /^\s*pwd\b/,
+  /^\s*echo\b/,
+  /^\s*printf\b/,
+  /^\s*wc\b/,
+  /^\s*sort\b/,
+  /^\s*uniq\b/,
+  /^\s*diff\b/,
+  /^\s*file\b/,
+  /^\s*stat\b/,
+  /^\s*du\b/,
+  /^\s*df\b/,
+  /^\s*tree\b/,
+  /^\s*which\b/,
+  /^\s*whereis\b/,
+  /^\s*type\b/,
+  /^\s*env\b/,
+  /^\s*printenv\b/,
+  /^\s*uname\b/,
+  /^\s*whoami\b/,
+  /^\s*id\b/,
+  /^\s*date\b/,
+  /^\s*cal\b/,
+  /^\s*uptime\b/,
+  /^\s*ps\b/,
+  /^\s*top\b/,
+  /^\s*htop\b/,
+  /^\s*free\b/,
+  /^\s*git\s+(status|log|diff|show|branch|remote|config\s+--get)/i,
+  /^\s*git\s+ls-/i,
+  /^\s*npm\s+(list|ls|view|info|search|outdated|audit)/i,
+  /^\s*yarn\s+(list|info|why|audit)/i,
+  /^\s*node\s+--version/i,
+  /^\s*python\s+--version/i,
+  /^\s*curl\s/i,
+  /^\s*wget\s+-O\s*-/i,
+  /^\s*jq\b/,
+  /^\s*sed\s+-n/i,
+  /^\s*awk\b/,
+  /^\s*rg\b/,
+  /^\s*fd\b/,
+  /^\s*bat\b/,
+  /^\s*exa\b/,
+  /^\s*rp-cli\b/,
+  /^\s*rpce-cli\b/,
+  /^\s*rp_exec\b/,
+  /^\s*rp_bind\b/,
 ];
 
 const REPROMPT_WRITE_PATTERNS = [
@@ -415,10 +416,10 @@ const REPROMPT_WRITE_PATTERNS = [
 ];
 
 const RP_CLI_INTERACTIVE_PATTERN =
-	/(^|\s)rp-cli\b.*(?:\s)(?:-i|--interactive)(?:\s|$)/i;
+	/(^|\s)rpce-cli\b.*(?:\s)(?:-i|--interactive)(?:\s|$)/i;
 
 const RP_CLI_EXEC_WRITE_PATTERN =
-	/(^|\s)rp-cli\b.*(?:\s)(?:-e|--exec)(?:\s*)[\s\S]*\b(edit|file_actions|file\s+(create|delete|move)|call\s+(apply-edits|file_actions))\b/i;
+	/(^|\s)rpce-cli\b.*(?:\s)(?:-e|--exec)(?:\s*)[\s\S]*\b(edit|file_actions|file\s+(create|delete|move)|call\s+(apply-edits|file_actions))\b/i;
 
 function isRepoPromptWriteCommand(command: string): boolean {
 	return REPROMPT_WRITE_PATTERNS.some((pattern) => pattern.test(command));
@@ -435,7 +436,7 @@ function isRepoPromptMcpWriteRequest(input: unknown): boolean {
 		return false;
 	}
 
-	// `rp` (repoprompt-mcp) proxies RepoPrompt MCP tools. Treat these as write-capable.
+	// `rp` (repoprompt-mcp) proxies RepoPrompt CE MCP tools. Treat these as write-capable.
 	// Be tolerant of tool name prefixing, e.g. RepoPrompt_apply_edits
 	const normalizedCall = call.trim();
 	return /(^|_)(apply[-_]edits)$/.test(normalizedCall) || /(^|_)(file_actions)$/.test(normalizedCall);
@@ -444,7 +445,7 @@ function isRepoPromptMcpWriteRequest(input: unknown): boolean {
 const AST_READ_ONLY_COMMANDS = new Set([
 	"cat", "head", "tail", "less", "more", "grep", "find", "ls", "pwd", "echo", "printf", "wc", "sort", "uniq",
 	"diff", "file", "stat", "du", "df", "tree", "which", "whereis", "type", "env", "printenv", "uname", "whoami",
-	"id", "date", "cal", "uptime", "ps", "top", "htop", "free", "jq", "awk", "rg", "fd", "bat", "exa", "rp-cli",
+	"id", "date", "cal", "uptime", "ps", "top", "htop", "free", "jq", "awk", "rg", "fd", "bat", "exa", "rpce-cli", "rp-cli",
 	"rp_exec", "rp_bind", "curl",
 ]);
 
@@ -516,12 +517,12 @@ function isInvocationReadOnly(invocation: { effectiveCommandName: string; effect
 }
 
 function isSafeCommand(command: string): boolean {
-	// Prevent using rp-cli via bash to enter interactive REPL while in plan mode
+	// Prevent using rpce-cli via bash to enter interactive REPL while in plan mode
 	if (RP_CLI_INTERACTIVE_PATTERN.test(command)) {
 		return false;
 	}
 
-	// Prevent using rp-cli via bash to perform edits/file actions while in plan mode
+	// Prevent using rpce-cli via bash to perform edits/file actions while in plan mode
 	if (RP_CLI_EXEC_WRITE_PATTERN.test(command)) {
 		return false;
 	}
@@ -593,7 +594,7 @@ export default function planModeExtension(pi: ExtensionAPI) {
 			persistPlanModeState();
 
 			if (ctx.hasUI) {
-				ctx.ui.notify("Plan mode enabled. Pi write tools disabled; bash and RepoPrompt writes are blocked.");
+				ctx.ui.notify("Plan mode enabled. Pi write tools disabled; bash and RepoPrompt CE writes are blocked.");
 			}
 
 			updateStatus(ctx);
@@ -628,7 +629,7 @@ export default function planModeExtension(pi: ExtensionAPI) {
 		},
 	});
 
-	// Block write operations in plan mode (bash + RepoPrompt + native file tools as a backstop)
+	// Block write operations in plan mode (bash + RepoPrompt CE + native file tools as a backstop)
 	pi.on("tool_call", async (event, ctx) => {
 		if (!planModeEnabled) return;
 
@@ -653,25 +654,29 @@ export default function planModeExtension(pi: ExtensionAPI) {
 			return;
 		}
 
-		if (event.toolName === "rp_exec" || event.toolName === "rp-cli") {
-			const input = event.input as { cmd?: unknown; command?: unknown };
-			const command = (input.cmd ?? input.command) as string | undefined;
-			if (typeof command !== "string") return;
+		if (
+      event.toolName === "rp_exec" ||
+      event.toolName === "rpce-cli" ||
+      event.toolName === "rp-cli"
+    ) {
+      const input = event.input as { cmd?: unknown; command?: unknown };
+      const command = (input.cmd ?? input.command) as string | undefined;
+      if (typeof command !== "string") return;
 
-			if (isRepoPromptWriteCommand(command)) {
-				return {
-					block: true,
-					reason: `Plan mode: RepoPrompt write command blocked. Use /plan to disable plan mode first.\nCommand: ${command}`,
-				};
-			}
-		}
+      if (isRepoPromptWriteCommand(command)) {
+        return {
+          block: true,
+          reason: `Plan mode: RepoPrompt CE write command blocked. Use /plan to disable plan mode first.\nCommand: ${command}`,
+        };
+      }
+    }
 
 		if (event.toolName === "rp") {
 			if (isRepoPromptMcpWriteRequest(event.input)) {
 				const call = (event.input as { call?: unknown } | undefined)?.call;
 				return {
 					block: true,
-					reason: `Plan mode: RepoPrompt write tool blocked. Use /plan to disable plan mode first.\nTool: rp(call=${String(call)})`,
+					reason: `Plan mode: RepoPrompt CE write tool blocked. Use /plan to disable plan mode first.\nTool: rp(call=${String(call)})`,
 				};
 			}
 		}

--- a/extensions/repoprompt-cli/README.md
+++ b/extensions/repoprompt-cli/README.md
@@ -2,16 +2,16 @@
 
 > **⚠ Deprecated and not supported for Pi versions >0.64.0.**  Consider instead using [`repoprompt-mcp`](../repoprompt-mcp/)/([`pi-repoprompt-mcp`](https://www.npmjs.com/package/pi-repoprompt-mcp)), which offers everything this extension has and several more reliability and QoL features, with none of the extra token overheads MCP tools typically entail.  This extension is no longer maintained but remains available for reference.
 
-I recommend exploring the RepoPrompt CLI more from the angle of an agent skill for writing scripts that invoke rp-cli, while using repoprompt-mcp for Pi-RepoPrompt integration.
+I recommend exploring the RepoPrompt CLI more from the angle of an agent skill for writing scripts that invoke rpce-cli, while using repoprompt-mcp for Pi-RepoPrompt integration.
 
 ---
 
-This folder contains the Pi extension that integrates the **RepoPrompt CLI** (`rp-cli`) into Pi.
+This folder contains the Pi extension that integrates the **RepoPrompt Community Edition CLI** (`rpce-cli`) into Pi.
 
 It provides two Pi tools:
 
 - `rp_bind` — bind to a specific RepoPrompt **window id** + **compose tab** (routing)
-- `rp_exec` — run `rp-cli -e <cmd>` against that binding
+- `rp_exec` — run `rpce-cli -e <cmd>` against that binding
 
 For discovery, prefer `windows` first: since v2.1.x, RepoPrompt includes tab/context reporting directly in that output, so you often no longer need a separate `workspace tabs` step just to find a bind target.
 

--- a/extensions/repoprompt-cli/index.ts
+++ b/extensions/repoprompt-cli/index.ts
@@ -242,7 +242,7 @@ function hasPipeOutsideQuotes(script: string): boolean {
  *
  * Registers two Pi tools:
  * - `rp_bind`: binds a RepoPrompt window + compose tab (routing)
- * - `rp_exec`: runs `rp-cli -e <cmd>` against that binding (quiet defaults, output truncation)
+ * - `rp_exec`: runs `rpce-cli -e <cmd>` against that binding (quiet defaults, output truncation)
  *
  * Safety goals:
  * - Prevent "unbound" rp_exec calls from operating on an unintended window/workspace
@@ -272,15 +272,15 @@ interface RpCliWindow {
 }
 
 const BindParams = Type.Object({
-  windowId: Type.Number({ description: "RepoPrompt window id (from `rp-cli -e windows`)" }),
-  tab: Type.String({ description: "RepoPrompt compose tab name or UUID" }),
+  windowId: Type.Number({ description: "RepoPrompt CE window id (from `rpce-cli -e windows`)" }),
+  tab: Type.String({ description: "RepoPrompt CE compose tab name or UUID" }),
 });
 
 const ExecParams = Type.Object({
-  cmd: Type.String({ description: "rp-cli exec string (e.g. `tree`, `select set src/ && context`)" }),
-  rawJson: Type.Optional(Type.Boolean({ description: "Pass --raw-json to rp-cli" })),
-  quiet: Type.Optional(Type.Boolean({ description: "Pass -q/--quiet to rp-cli (default: true)" })),
-  failFast: Type.Optional(Type.Boolean({ description: "Pass --fail-fast to rp-cli (default: true)" })),
+  cmd: Type.String({ description: "rpce-cli exec string (e.g. `tree`, `select set src/ && context`)" }),
+  rawJson: Type.Optional(Type.Boolean({ description: "Pass --raw-json to rpce-cli" })),
+  quiet: Type.Optional(Type.Boolean({ description: "Pass -q/--quiet to rpce-cli (default: true)" })),
+  failFast: Type.Optional(Type.Boolean({ description: "Pass --fail-fast to rpce-cli (default: true)" })),
   timeoutMs: Type.Optional(Type.Number({ description: "Timeout in ms (default: 15 minutes)" })),
   maxOutputChars: Type.Optional(Type.Number({ description: "Truncate output to this many chars (default: 12000)" })),
   windowId: Type.Optional(Type.Number({ description: "Override bound window id for this call" })),
@@ -680,7 +680,7 @@ function parseReadFileRequest(cmd: string): ParsedReadFileRequest | null {
       continue;
     }
 
-    // key=value pairs (rp-cli supports key=value and also dash->underscore)
+    // key=value pairs (rpce-cli supports key=value and also dash->underscore)
     const eqIdx = arg.indexOf("=");
     if (eqIdx > 0) {
       const key = normalizeKey(arg.slice(0, eqIdx));
@@ -777,7 +777,7 @@ function parseReadFileRequest(cmd: string): ParsedReadFileRequest | null {
 
   let cmdToRun = [commandNameRaw, ...filteredArgs].filter(Boolean).join(" ");
 
-  // Canonicalize into rp-cli's documented read shorthand syntax so that equivalent forms behave consistently
+  // Canonicalize into rpce-cli's documented read shorthand syntax so that equivalent forms behave consistently
   // (especially for bypass_cache=true tests)
   const safePathForRewrite = /^\S+$/.test(inputPath);
   if (!sawUnknownArg && safePathForRewrite) {
@@ -1668,7 +1668,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     try {
-      const result = await pi.exec("rp-cli", ["--raw-json", "-q", "-e", "windows"], { timeout: 10_000 });
+      const result = await pi.exec("rpce-cli", ["--raw-json", "-q", "-e", "windows"], { timeout: 10_000 });
 
       if ((result.code ?? 0) !== 0) {
         return windowsCache?.windows ?? [];
@@ -2100,7 +2100,7 @@ export default function (pi: ExtensionAPI) {
 
     args.push("-e", cmd);
 
-    const result = await pi.exec("rp-cli", args, { timeout });
+    const result = await pi.exec("rpce-cli", args, { timeout });
 
     const stdout = result.stdout ?? "";
     const stderr = result.stderr ?? "";
@@ -2108,7 +2108,7 @@ export default function (pi: ExtensionAPI) {
     const output = [stdout, stderr].filter(Boolean).join("\n").trim();
 
     if (exitCode !== 0) {
-      throw new Error(output || `rp-cli exited with status ${exitCode}`);
+      throw new Error(output || `rpce-cli exited with status ${exitCode}`);
     }
 
     return { stdout, stderr, exitCode, output };
@@ -2894,7 +2894,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "rp_exec",
     label: "RepoPrompt Exec",
-    description: "Run rp-cli in the bound RepoPrompt window/tab, with quiet defaults and output truncation",
+    description: "Run rpce-cli in the bound RepoPrompt CE window/tab, with quiet defaults and output truncation",
     parameters: ExecParams,
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
@@ -2985,10 +2985,10 @@ export default function (pi: ExtensionAPI) {
       if (windowId === undefined || tab === undefined) {
         onUpdate({
           status:
-            "Running rp-cli without a bound window/tab (non-deterministic). Bind first with rp_bind(windowId, tab)",
+            "Running rpce-cli without a bound window/tab (non-deterministic). Bind first with rp_bind(windowId, tab)",
         });
       } else {
-        onUpdate({ status: `Running rp-cli in window ${windowId}, tab "${tab}"…` });
+        onUpdate({ status: `Running rpce-cli in window ${windowId}, tab "${tab}"…` });
       }
 
       let stdout = "";
@@ -2997,7 +2997,7 @@ export default function (pi: ExtensionAPI) {
       let execError: string | undefined;
 
       try {
-        const result = await pi.exec("rp-cli", rpArgs, { signal, timeout: timeoutMs });
+        const result = await pi.exec("rpce-cli", rpArgs, { signal, timeout: timeoutMs });
         stdout = result.stdout ?? "";
         stderr = result.stderr ?? "";
         exitCode = result.code ?? 0;
@@ -3007,7 +3007,7 @@ export default function (pi: ExtensionAPI) {
 
       const combinedOutput = [stdout, stderr].filter(Boolean).join("\n").trim();
 
-      let rawOutput = execError ? `rp-cli execution failed: ${execError}` : combinedOutput;
+      let rawOutput = execError ? `rpce-cli execution failed: ${execError}` : combinedOutput;
 
       let rpReadcache: RpReadcacheMetaV1 | null = null;
 
@@ -3082,19 +3082,19 @@ export default function (pi: ExtensionAPI) {
 
       let outputForUser = rawOutput;
       if (editNoop) {
-        const rpCliOutput = rawOutput.length > 0 ? `\n--- rp-cli output ---\n${rawOutput}` : "";
+        const rpCliOutput = rawOutput.length > 0 ? `\n--- rpce-cli output ---\n${rawOutput}` : "";
 
         if (shouldFailNoopEdit) {
           outputForUser =
             "RepoPrompt edit made no changes (0 edits applied). This usually means the search string was not found.\n" +
             "If this was expected, rerun with failOnNoopEdits=false. Otherwise, verify the search text or rerun with rawJson=true / quiet=false.\n" +
-            "Tip: for tricky edits with multiline content, use rp-cli directly: rp-cli -c apply_edits -j '{...}'" +
+            "Tip: for tricky edits with multiline content, use rpce-cli directly: rpce-cli -c apply_edits -j '{...}'" +
             rpCliOutput;
         } else {
           outputForUser =
             "RepoPrompt edit made no changes (0 edits applied).\n" +
             "RepoPrompt may report this as an error (e.g. 'search block not found'), but failOnNoopEdits=false is treating it as non-fatal.\n" +
-            "Tip: for tricky edits with multiline content, use rp-cli directly: rp-cli -c apply_edits -j '{...}'" +
+            "Tip: for tricky edits with multiline content, use rpce-cli directly: rpce-cli -c apply_edits -j '{...}'" +
             rpCliOutput;
         }
       }

--- a/extensions/repoprompt-cli/readcache/constants.ts
+++ b/extensions/repoprompt-cli/readcache/constants.ts
@@ -1,4 +1,4 @@
-// readcache/constants.ts - constants for read_file caching via rp-cli
+// readcache/constants.ts - constants for read_file caching via rpce-cli
 
 export const RP_READCACHE_META_VERSION = 1 as const;
 export const RP_READCACHE_CUSTOM_TYPE = "repoprompt-cli-readcache" as const;

--- a/extensions/repoprompt-cli/readcache/resolve.ts
+++ b/extensions/repoprompt-cli/readcache/resolve.ts
@@ -1,4 +1,4 @@
-// readcache/resolve.ts - resolve rp-cli read_file paths to local absolute paths
+// readcache/resolve.ts - resolve rpce-cli read_file paths to local absolute paths
 
 import { access } from "node:fs/promises";
 import * as path from "node:path";
@@ -32,7 +32,7 @@ function normalizeRootLine(line: string): string | null {
 
     // Expand home
     if (trimmed.startsWith("~")) {
-        // We intentionally don't expand here; rp-cli roots should be absolute already
+        // We intentionally don't expand here; rpce-cli roots should be absolute already
         return null;
     }
 
@@ -72,11 +72,11 @@ async function fetchWindowRootsViaCli(pi: ExtensionAPI, windowId: number, tab?: 
         args.push("-t", tab);
     }
 
-    // Use rp-cli exec mode to call the underlying MCP tool. This reliably returns one absolute root per line.
-    // (Using `tree type=roots` is NOT supported by rp-cli and can return an error string instead of roots.)
+    // Use rpce-cli exec mode to call the underlying MCP tool. This reliably returns one absolute root per line.
+    // (Using `tree type=roots` is NOT supported by rpce-cli and can return an error string instead of roots.)
     args.push("-q", "-e", 'call get_file_tree {"type":"roots"}');
 
-    const result = await pi.exec("rp-cli", args, { timeout: 10_000 });
+    const result = await pi.exec("rpce-cli", args, { timeout: 10_000 });
     const stdout = result.stdout ?? "";
     const stderr = result.stderr ?? "";
     const output = [stdout, stderr].filter(Boolean).join("\n");

--- a/extensions/repoprompt-mcp/README.md
+++ b/extensions/repoprompt-mcp/README.md
@@ -253,7 +253,7 @@ If the RepoPrompt CE MCP server stops responding (for example, if the RepoPrompt
 
 If RepoPrompt is not running when Pi starts, the extension auto-pauses itself after a quick connection timeout.  While paused, the `rp` tool returns a short error directing the agent to use native tools.  Run `/rp reconnect` once RepoPrompt is open to resume, and the agent will be notified that `rp` is available again.
 
-If `autoLaunchApp` is enabled, the extension will try to open the RepoPrompt CE app automatically before pausing.  The app path is inferred from the `command` config (e.g. `/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp` → `/Applications/Repo Prompt.app`), or you can set `appPath` explicitly.  After launching, the extension waits a few seconds and retries the connection once; if that also fails, it auto-pauses as usual.
+If `autoLaunchApp` is enabled, the extension will try to open the RepoPrompt CE app automatically before pausing.  The app path is inferred from the `command` config (e.g. `/Applications/RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp` → `/Applications/Repo Prompt CE.app`), or you can set `appPath` explicitly.  After launching, the extension waits a few seconds and retries the connection once; if that also fails, it auto-pauses as usual.
 
 ### "No matching window found"
 - Your `cwd` may not match any RepoPrompt CE workspace root

--- a/extensions/repoprompt-mcp/README.md
+++ b/extensions/repoprompt-mcp/README.md
@@ -50,21 +50,21 @@ Forked sessions inherit the parent session-plus-node's window, tab, and auto-sel
 
 - RepoPrompt MCP server configured and reachable (stdio transport)
   - If the server is not configured/auto-detected, the extension will still load, but `rp(...)` will error until you configure it
-- `rp-cli` available in `PATH` is recommended (used as a fallback for window discovery)
+- `rpce-cli` available in `PATH` is recommended (used as a fallback for window discovery)
 
 ### Compatibility notes
 
 This extension tries to be tolerant of **tool name prefixing** (e.g. `RepoPrompt_list_windows` vs `list_windows`), but it is still dependent on a small set of capabilities and their semantics remaining reasonably stable across RepoPrompt versions:
 
 - **Window discovery**: `list_windows`
-  - If `list_windows` is not exposed by the MCP server, the extension falls back to `rp-cli -e 'windows'`
+  - If `list_windows` is not exposed by the MCP server, the extension falls back to `rpce-cli -e 'windows'`
   - If neither is available, window listing/binding features will be limited
 - **Workspace root discovery (auto-bind by cwd)**: `get_file_tree` with `{ type: "roots" }` (scoped by `_windowID`)
   - If unavailable (or if parameters/semantics change), auto-binding may be disabled or less accurate
 - Selection summary: `manage_selection` with `{ op: "get", view: "files" }` and `{ op: "get", view: "summary" }`
   - If these are unavailable (or if parameters/semantics change), the status output may omit file/token counts
 
-If RepoPrompt renames/removes these tools or changes their required parameters/output formats, this extension may need updates
+If RepoPrompt CE renames/removes these tools or changes their required parameters/output formats, this extension may need updates
 
 ## Installation
 
@@ -86,13 +86,13 @@ If RepoPrompt renames/removes these tools or changes their required parameters/o
    npm run build
    ```
 
-3. Configure the RepoPrompt MCP server (if not auto-detected):
+3. Configure the RepoPrompt CE MCP server (if not auto-detected):
 
    Create `~/.pi/agent/extensions/repoprompt-mcp.json`:
 
    ```json
    {
-     "command": "/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp",
+     "command": "'/Applications/RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp'",
      "args": []
    }
    ```
@@ -103,13 +103,13 @@ If RepoPrompt renames/removes these tools or changes their required parameters/o
    {
      "mcpServers": {
        "RepoPrompt": {
-         "command": "/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp"
+         "command": "'/Applications/RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp'"
        }
      }
    }
    ```
 
-4. If you already connect to RepoPrompt through another extension (e.g. a generic MCP adapter), avoid double-connecting.
+4. If you already connect to RepoPrompt CE through another extension (e.g. a generic MCP adapter), avoid double-connecting.
 
 ## Usage
 
@@ -148,7 +148,7 @@ Examples:
 // Status (connection + binding)
   rp({ })
 
-// List windows (best-effort; uses MCP tool if available, otherwise rp-cli)
+// List windows (best-effort; uses MCP tool if available, otherwise rpce-cli)
 rp({ windows: true })
 
 // Bind to a specific window (does not change RepoPrompt active window)
@@ -206,7 +206,7 @@ Create `~/.pi/agent/extensions/repoprompt-mcp.json`:
 }
 ```
 
-`collapsedMaxLines` controls how many rendered lines of RepoPrompt tool output Pi shows before the result is expanded for the generic fallback path.  In addition, the extension now emits hand-authored one-line or two-line collapsed summaries for common non-mutating actions like `read_file`, `file_search`, `get_file_tree`, `get_code_structure`, `workspace_context`, `windows`, `bind`, and `status`; these are derived from Pi's own request metadata rather than RepoPrompt's returned prose.  Unknown or unsupported tools still fall back to the normal `collapsedMaxLines` behavior.  LOC-changing operations are the other exception: verbose RepoPrompt `apply_edits` and rendered `file_actions create/delete` results ignore `collapsedMaxLines` once normalized into `details.diff`, so the full rendered code changes remain visible.
+`collapsedMaxLines` controls how many rendered lines of RepoPrompt CE tool output Pi shows before the result is expanded for the generic fallback path.  In addition, the extension now emits hand-authored one-line or two-line collapsed summaries for common non-mutating actions like `read_file`, `file_search`, `get_file_tree`, `get_code_structure`, `workspace_context`, `windows`, `bind`, and `status`; these are derived from Pi's own request metadata rather than RepoPrompt's returned prose.  Unknown or unsupported tools still fall back to the normal `collapsedMaxLines` behavior.  LOC-changing operations are the other exception: verbose RepoPrompt `apply_edits` and rendered `file_actions create/delete` results ignore `collapsedMaxLines` once normalized into `details.diff`, so the full rendered code changes remain visible.
 
 Options:
 
@@ -215,7 +215,7 @@ Options:
 | `command` | auto-detect | MCP server command |
 | `args` | `[]` | MCP server args |
 | `env` | unset | Extra environment variables for the MCP server |
-| `toolCallTimeoutMs` | `5400000` | MCP tool call timeout in milliseconds for RepoPrompt tools like `context_builder` and `oracle_send` (90 minutes by default) |
+| `toolCallTimeoutMs` | `5400000` | MCP tool call timeout in milliseconds for RepoPrompt CE tools like `context_builder` and `oracle_send` (90 minutes by default) |
 | `autoBindOnStart` | `true` | Auto-detect and bind on session start, then reconcile the branch-safe tab for the chosen window |
 | `persistBinding` | `true` | Persist window and tab bindings in Pi session history for branch-safe replay |
 | `confirmDeletes` | `true` | Block delete operations unless `allowDelete: true` |
@@ -224,10 +224,10 @@ Options:
 | `autoSelectReadSlices` | `true` | Automatically track `read_file` calls by adding slices/full-file selection via `manage_selection`, so `oracle_send` (or a manually created Oracle chat in the RP app) uses everything the agent has read as context; these file/slice selections are **branch-safe** across `/tree` rewinds and `/fork`ed session branches via extension-owned snapshot replay |
 | `oracleDefaultMode` | `"chat"` | Default mode for `/rp oracle` when `--mode` is omitted (`chat`, `plan`, `edit`, or `review`) |
 | `collapsedMaxLines` | `3` | Lines shown in collapsed view |
-| `diffViewMode` | `"auto"` | Diff layout for RepoPrompt `git` / `apply_edits` fenced diff output (`auto`, `split`, `unified`) |
+| `diffViewMode` | `"auto"` | Diff layout for RepoPrompt CE `git` / `apply_edits` fenced diff output (`auto`, `split`, `unified`) |
 | `diffSplitMinWidth` | `120` | Minimum render width before `diffViewMode: "auto"` uses split diff layout |
 | `suppressHostDisconnectedLog` | `true` | Filter noisy stderr from macOS `repoprompt-mcp` (disconnect/retry bootstrap logs) |
-| `autoLaunchApp` | `false` | Auto-launch the RepoPrompt app when the MCP server is unreachable at startup |
+| `autoLaunchApp` | `false` | Auto-launch the RepoPrompt CE app when the MCP server is unreachable at startup |
 | `appPath` | inferred | Explicit path to `Repo Prompt.app`; if omitted, inferred from the `.app` ancestor of `command` |
 
 Automatic tab restoration and provisioning is driven by `autoBindOnStart` and `persistBinding`; there is no separate tab-only configuration surface. Adaptive diff layout applies only to RepoPrompt `git` and `apply_edits` outputs that arrive as fenced `diff` blocks; other rendered output stays on the existing text-based path.
@@ -243,27 +243,27 @@ but this is best-effort
 
 ## Troubleshooting
 
-### "Not connected to RepoPrompt"
-- Ensure RepoPrompt is running
+### "Not connected to RepoPrompt CE"
+- Ensure RepoPrompt CE is running (Repo Prompt Classic Edition is no longer supported)
 - Verify the MCP server command in config
 - Run `/rp reconnect`
 
-### Pi becomes unresponsive after closing/restarting RepoPrompt
-If the RepoPrompt MCP server stops responding (for example, if the RepoPrompt app is closed while Pi stays open), tool calls may time out. When that happens, the extension will drop the connection and you can recover with `/rp reconnect`.
+### Pi becomes unresponsive after closing/restarting RepoPrompt CE
+If the RepoPrompt CE MCP server stops responding (for example, if the RepoPrompt app is closed while Pi stays open), tool calls may time out. When that happens, the extension will drop the connection and you can recover with `/rp reconnect`.
 
 If RepoPrompt is not running when Pi starts, the extension auto-pauses itself after a quick connection timeout.  While paused, the `rp` tool returns a short error directing the agent to use native tools.  Run `/rp reconnect` once RepoPrompt is open to resume, and the agent will be notified that `rp` is available again.
 
-If `autoLaunchApp` is enabled, the extension will try to open the RepoPrompt app automatically before pausing.  The app path is inferred from the `command` config (e.g. `/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp` → `/Applications/Repo Prompt.app`), or you can set `appPath` explicitly.  After launching, the extension waits a few seconds and retries the connection once; if that also fails, it auto-pauses as usual.
+If `autoLaunchApp` is enabled, the extension will try to open the RepoPrompt CE app automatically before pausing.  The app path is inferred from the `command` config (e.g. `/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp` → `/Applications/Repo Prompt.app`), or you can set `appPath` explicitly.  After launching, the extension waits a few seconds and retries the connection once; if that also fails, it auto-pauses as usual.
 
 ### "No matching window found"
-- Your `cwd` may not match any RepoPrompt workspace root
+- Your `cwd` may not match any RepoPrompt CE workspace root
 - Use `/rp windows` to list windows
 - Use `/rp bind` to pick one
 
 ### Window listing doesn’t work
-- If the MCP server does not expose a `list_windows` tool, this extension uses `rp-cli -e 'windows'`
-- Make sure `rp-cli` is installed and on your `PATH`
-- If RepoPrompt is in single-window mode, `rp-cli -e 'windows'` may report single-window mode
+- If the MCP server does not expose a `list_windows` tool, this extension uses `rpce-cli -e 'windows'`
+- Make sure `rpce-cli` is installed and on your `PATH`
+- If RepoPrompt CE is in single-window mode, `rpce-cli -e 'windows'` may report single-window mode
 
 ### Delete operation blocked
 - Pass `allowDelete: true` on the `rp` call

--- a/extensions/repoprompt-mcp/repoprompt-mcp.json
+++ b/extensions/repoprompt-mcp/repoprompt-mcp.json
@@ -1,5 +1,5 @@
 {
-  "command": "/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp",
+  "command": "/Applications/RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp",
   "args": [],
   "autoBindOnStart": true,
   "persistBinding": true,

--- a/extensions/repoprompt-mcp/src/binding.ts
+++ b/extensions/repoprompt-mcp/src/binding.ts
@@ -156,7 +156,7 @@ export function restoreBinding(ctx: ExtensionContext, config: RpConfig): RpBindi
 }
 
 /**
- * Parse window list response from RepoPrompt
+ * Parse window list response from RepoPrompt CE
  */
 export function parseWindowList(text: string): RpWindow[] {
   const windows: RpWindow[] = [];
@@ -399,12 +399,12 @@ async function fetchWindowsViaCli(pi?: ExtensionAPI): Promise<RpWindow[]> {
 
     // Prefer pi.exec when available, since Pi often runs with a richer PATH than this Node process
     if (pi) {
-      const result = await pi.exec("rp-cli", ["-e", "windows"], { timeout: 5000 });
+      const result = await pi.exec("rpce-cli", ["-e", "windows"], { timeout: 5000 });
       stdout = result.stdout ?? "";
       stderr = result.stderr ?? "";
     } else {
       const result = await execFileAsync(
-        "rp-cli",
+        "rpce-cli",
         ["-e", "windows"],
         { timeout: 5000, maxBuffer: 1024 * 1024 }
       );
@@ -419,7 +419,7 @@ async function fetchWindowsViaCli(pi?: ExtensionAPI): Promise<RpWindow[]> {
       return windows;
     }
 
-    // RepoPrompt CLI reports single-window mode when multiple windows aren't available
+    // RepoPrompt CE CLI reports single-window mode when multiple windows aren't available
     if (output.toLowerCase().includes("single-window mode")) {
       return [{ id: 1, workspace: "single-window", roots: [] }];
     }
@@ -432,8 +432,8 @@ async function fetchWindowsViaCli(pi?: ExtensionAPI): Promise<RpWindow[]> {
     // Node's execFile throws { code: "ENOENT" }, while pi.exec may throw an Error with an ENOENT-ish message
     if (error.code === "ENOENT" || message.includes("ENOENT") || message.toLowerCase().includes("not found")) {
       throw new Error(
-        "rp-cli not found in PATH (required for window listing/binding). " +
-          "Install rp-cli or ensure Pi inherits your shell PATH."
+        "rpce-cli not found in PATH (required for window listing/binding). " +
+          "Install rpce-cli within RepoPrompt CE MCP Settings or ensure Pi inherits your shell PATH."
       );
     }
 
@@ -442,12 +442,12 @@ async function fetchWindowsViaCli(pi?: ExtensionAPI): Promise<RpWindow[]> {
 }
 
 /**
- * Fetch list of RepoPrompt windows (without roots)
+ * Fetch list of RepoPrompt CE windows (without roots)
  */
 export async function fetchWindows(pi?: ExtensionAPI): Promise<RpWindow[]> {
   const client = getRpClient();
   if (!client.isConnected) {
-    throw new Error("Not connected to RepoPrompt");
+    throw new Error("Not connected to RepoPrompt CE");
   }
 
   const windowsFromMcp = await fetchWindowsViaMcp(client);
@@ -665,7 +665,7 @@ export async function findRecoveryWindowBySelectionPaths(
 export async function fetchWindowRoots(windowId: number): Promise<string[]> {
   const client = getRpClient();
   if (!client.isConnected) {
-    throw new Error("Not connected to RepoPrompt");
+    throw new Error("Not connected to RepoPrompt CE");
   }
 
   const getFileTreeToolName = resolveToolName(client.tools, "get_file_tree");
@@ -1103,7 +1103,7 @@ export async function fetchWindowTabs(
   client: ReturnType<typeof getRpClient> = getRpClient()
 ): Promise<RpTab[]> {
   if (!client.isConnected) {
-    throw new Error("Not connected to RepoPrompt");
+    throw new Error("Not connected to RepoPrompt CE");
   }
 
   const bindContextToolName = resolveToolName(client.tools, "bind_context");
@@ -1146,7 +1146,7 @@ async function selectTab(
 
   if (result.isError) {
     const text = extractTextContent(result.content);
-    throw new Error(text || `Failed to bind RepoPrompt tab ${tabId}`);
+    throw new Error(text || `Failed to bind RepoPrompt CE tab ${tabId}`);
   }
 }
 
@@ -1156,7 +1156,7 @@ async function createBoundTab(
 ): Promise<RpTab> {
   const manageWorkspacesToolName = resolveToolName(client.tools, "manage_workspaces");
   if (!manageWorkspacesToolName) {
-    throw new Error("RepoPrompt manage_workspaces tool not available");
+    throw new Error("RepoPrompt CE manage_workspaces tool not available");
   }
 
   const tabsBeforeCreate = await fetchWindowTabs(windowId, client);
@@ -1170,7 +1170,7 @@ async function createBoundTab(
 
   if (result.isError) {
     const text = extractTextContent(result.content);
-    throw new Error(text || "Failed to create RepoPrompt tab");
+    throw new Error(text || "Failed to create RepoPrompt CE tab");
   }
 
   const createdTabs = parseTabsFromJson(extractJsonContent(result.content)) ?? parseTabList(extractTextContent(result.content));
@@ -1182,7 +1182,7 @@ async function createBoundTab(
     const newTabs = tabsAfterCreate.filter((tab) => !previousIds.has(tab.id));
 
     if (newTabs.length !== 1) {
-      throw new Error("RepoPrompt did not report the created tab unambiguously");
+      throw new Error("RepoPrompt CE did not report the created tab unambiguously");
     }
 
     createdTab = newTabs[0];
@@ -1204,13 +1204,13 @@ export async function bindToTab(
   const window = windows.find((w) => w.id === windowId);
 
   if (!window && windows.length > 0) {
-    throw new Error(`RepoPrompt window ${windowId} not found`);
+    throw new Error(`RepoPrompt CE window ${windowId} not found`);
   }
 
   const tabs = await fetchWindowTabs(windowId, client);
   const liveTab = findLiveTab(tabs, tabReference);
   if (!liveTab) {
-    throw new Error(`RepoPrompt tab ${JSON.stringify(tabReference)} not found in window ${windowId}`);
+    throw new Error(`RepoPrompt CE tab ${JSON.stringify(tabReference)} not found in window ${windowId}`);
   }
 
   if (liveTab.isBound !== true) {
@@ -1238,7 +1238,7 @@ export async function createAndBindTab(
   const window = windows.find((w) => w.id === windowId);
 
   if (!window && windows.length > 0) {
-    throw new Error(`RepoPrompt window ${windowId} not found`);
+    throw new Error(`RepoPrompt CE window ${windowId} not found`);
   }
 
   const createdTab = await createBoundTab(windowId, client);
@@ -1508,7 +1508,7 @@ export async function bindToWindow(
   const window = windows.find((w) => w.id === windowId);
 
   if (!window && windows.length > 0) {
-    throw new Error(`RepoPrompt window ${windowId} not found`);
+    throw new Error(`RepoPrompt CE window ${windowId} not found`);
   }
 
   const binding: RpBinding = {

--- a/extensions/repoprompt-mcp/src/config.ts
+++ b/extensions/repoprompt-mcp/src/config.ts
@@ -1,4 +1,4 @@
-// config.ts - Configuration loading for RepoPrompt MCP extension
+// config.ts - Configuration loading for RepoPrompt CE MCP extension
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -18,10 +18,10 @@ const DEFAULT_CONFIG: RpConfig = {
   diffSplitMinWidth: 120,
   suppressHostDisconnectedLog: true,
 
-  // Off by default: preserves RepoPrompt's default read_file behavior unless explicitly enabled
+  // Off by default: preserves RepoPrompt CE's default read_file behavior unless explicitly enabled
   readcacheReadFile: false,
 
-  // On by default: mirrors RepoPrompt Agent Mode behavior (reads automatically curate selection)
+  // On by default: mirrors RepoPrompt CE Agent Mode behavior (reads automatically curate selection)
   autoSelectReadSlices: true,
 
   // /rp oracle uses this mode when --mode is not provided
@@ -43,14 +43,14 @@ const CONFIG_LOCATIONS = [
   () => path.join(os.homedir(), ".config", "mcp", "mcp.json"),
 ];
 
-// Common RepoPrompt MCP server commands
+// Common RepoPrompt CE MCP server commands
 const REPOPROMPT_SERVER_CANDIDATES = [
   // Direct command
   { command: "rp-mcp-server", args: [] },
   // Via npx
   { command: "npx", args: ["rp-mcp-server"] },
-  // Via RepoPrompt CLI
-  { command: "rp-cli", args: ["mcp-server"] },
+  // Via RepoPrompt CE CLI
+  { command: "rpce-cli", args: ["mcp-server"] },
 ];
 
 interface McpServerEntry {
@@ -85,7 +85,7 @@ function findRepoPromptInMcpConfig(): McpServerEntry | null {
 
     if (!config?.mcpServers) continue;
 
-    // Look for RepoPrompt server (case-insensitive)
+    // Look for RepoPrompt CE server (case-insensitive)
     for (const [name, entry] of Object.entries(config.mcpServers)) {
       if (name.toLowerCase().includes("repoprompt") || name.toLowerCase() === "rp") {
         return entry;
@@ -213,7 +213,7 @@ export function loadConfig(overrides?: Partial<RpConfig>): RpConfig {
 const FILTERED_STDERR_SUBSTRINGS = [
   // Clean disconnect / shutdown
   "BootstrapSocketProxy: Bridge task failed: hostDisconnected",
-  // RepoPrompt app closed while Pi stays running
+  // RepoPrompt CE app closed while Pi stays running
   "BootstrapSocketProxy: Bridge task failed: connectionReset",
   "Bootstrap connection lost",
   "Retrying in",
@@ -232,7 +232,7 @@ function maybeWrapServerCommand(
     return server;
   }
 
-  // This noisy line is emitted by the macOS RepoPrompt MCP binary on clean disconnect
+  // This noisy line is emitted by the macOS RepoPrompt CE MCP binary on clean disconnect
   // It is written to stderr, not MCP stdout, so it's safe to filter
   if (process.platform !== "darwin") {
     return server;
@@ -259,7 +259,7 @@ function maybeWrapServerCommand(
 
 /**
  * Infer the .app bundle path from an MCP server command that lives inside a .app bundle.
- * e.g. "/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp" → "/Applications/Repo Prompt.app"
+ * e.g. "/Applications/RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp" → "/Applications/RepoPrompt CE.app"
  */
 export function inferAppPath(config: RpConfig): string | null {
   if (config.appPath) {
@@ -276,7 +276,7 @@ export function inferAppPath(config: RpConfig): string | null {
  * Get the server command and args, or return null if not found
  *
  * We avoid throwing on startup because a missing server is a common first-run condition
- * (users may not have installed RepoPrompt / rp-mcp-server yet). Instead we surface this
+ * (users may not have installed RepoPrompt CE/ rp-mcp-server yet). Instead we surface this
  * as a non-fatal warning and only error when a user actually tries to use rp features
  */
 export function getServerCommand(config: RpConfig): { command: string; args: string[] } | null {

--- a/extensions/rp-native-tools-lock/index.ts
+++ b/extensions/rp-native-tools-lock/index.ts
@@ -1,11 +1,11 @@
 /**
  * RP Native Tools Lock
  *
- * Disables Pi's native repo-file tools (read/write/edit/ls/find/grep) when RepoPrompt tools are available.
+ * Disables Pi's native repo-file tools (read/write/edit/ls/find/grep) when RepoPrompt CE tools are available.
  *
  * Why:
  * - Some models will "reach" for the native tools because they appear first / are more familiar
- * - If RepoPrompt is available, we want to force repo-scoped work through rp (MCP) or rp_exec (CLI)
+ * - If RepoPrompt CE is available, we want to force repo-scoped work through rp (MCP) or rp_exec (CLI)
  *
  * Modes (user-facing):
  * - off     : no enforcement
@@ -15,7 +15,7 @@
  *
  * Advanced modes (set via config file):
  * - rp-mcp  : enforce when the `rp` tool exists
- * - rp-cli  : enforce when the `rp_exec` tool exists
+ * - rpce-cli  : enforce when the `rp_exec` tool exists
  *
  * Hotkeys:
  * - Alt+L: toggle lock mode (off ↔ auto)
@@ -33,7 +33,7 @@ import { dirname, join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key, type KeyId } from "@earendil-works/pi-tui";
 
-type Mode = "off" | "auto" | "rp-mcp" | "rp-cli";
+type Mode = "off" | "auto" | "rp-mcp" | "rpce-cli";
 
 interface LockState {
 	mode: Mode;
@@ -44,7 +44,7 @@ const CONFIG_PATH = join(homedir(), ".pi", "agent", "extensions", "rp-native-too
 
 const REQUIRED_TOOL_BY_MODE: Record<Exclude<Mode, "off" | "auto">, string> = {
 	"rp-mcp": "rp",
-	"rp-cli": "rp_exec",
+	"rpce-cli": "rp_exec",
 };
 
 const NATIVE_FILE_TOOLS = ["read", "write", "edit", "ls", "find", "grep"];
@@ -62,7 +62,14 @@ function normalizeMode(raw: string | undefined): Mode | undefined {
 	if (value === "off" || value === "disabled" || value === "none") return "off";
 	if (value === "auto" || value === "aut" || value === "automatic") return "auto";
 	if (value === "rp-mcp" || value === "mcp" || value === "rp") return "rp-mcp";
-	if (value === "rp-cli" || value === "cli" || value === "rp_exec" || value === "rp-exec") return "rp-cli";
+	if (
+    value === "rpce-cli" ||
+    value === "rpce-cli" ||
+    value === "cli" ||
+    value === "rp_exec" ||
+    value === "rp-exec"
+  )
+    return "rpce-cli";
 
 	return undefined;
 }
@@ -122,9 +129,9 @@ function computeEffectiveMode(
 
 	if (requestedMode === "auto") {
 		// In auto mode, respect the user's tool configuration.
-		// We only prefer a RepoPrompt entrypoint if the user has enabled it.
+		// We only prefer a RepoPrompt CE entrypoint if the user has enabled it.
 		if (activeToolNames.has("rp")) return { effectiveMode: "rp-mcp", requiredTool: "rp" };
-		if (activeToolNames.has("rp_exec")) return { effectiveMode: "rp-cli", requiredTool: "rp_exec" };
+		if (activeToolNames.has("rp_exec")) return { effectiveMode: "rpce-cli", requiredTool: "rp_exec" };
 		return { effectiveMode: "off", requiredTool: undefined };
 	}
 
@@ -136,7 +143,7 @@ function computeEffectiveMode(
 }
 
 function buildStatusText(effectiveMode: EffectiveMode): string | undefined {
-	if (effectiveMode === "rp-mcp" || effectiveMode === "rp-cli") {
+	if (effectiveMode === "rp-mcp" || effectiveMode === "rpce-cli") {
 		return "RP 🔒";
 	}
 	return undefined;
@@ -173,7 +180,7 @@ function enforceMode(
 	const blocked = new Set(NATIVE_FILE_TOOLS.filter((t) => allToolNames.has(t)));
 	const next = active.filter((t) => !blocked.has(t));
 
-	// Ensure the required RepoPrompt tool stays available
+	// Ensure the required RepoPrompt CE tool stays available
 	if (!next.includes(requiredTool)) next.push(requiredTool);
 
 
@@ -261,7 +268,7 @@ export default function rpNativeToolsLock(pi: ExtensionAPI): void {
 
 	pi.registerCommand("rp-tools-lock", {
 		description:
-			"RepoPrompt-first tooling: off | auto (disables read/write/edit/ls/find/grep). Advanced modes are available via config file.",
+			"RepoPrompt CE-first tooling: off | auto (disables read/write/edit/ls/find/grep). Advanced modes are available via config file.",
 		handler: async (args, ctx) => {
 			const raw = args?.trim();
 
@@ -274,7 +281,7 @@ export default function rpNativeToolsLock(pi: ExtensionAPI): void {
 					return;
 				}
 
-				const choice = await ctx.ui.select("RepoPrompt tool policy", ALLOWED_MODES);
+				const choice = await ctx.ui.select("RepoPrompt CE tool policy", ALLOWED_MODES);
 				if (!choice) return;
 				state = { mode: choice as Mode };
 			} else {
@@ -282,7 +289,7 @@ export default function rpNativeToolsLock(pi: ExtensionAPI): void {
 				if (!mode || !ALLOWED_MODES.includes(mode)) {
 					const message =
 						`Usage: /rp-tools-lock <off|auto> (got: ${raw})\n` +
-						"Advanced modes (rp-mcp/rp-cli) can be set via: " +
+						"Advanced modes (rp-mcp/rpce-cli) can be set via: " +
 						"~/.pi/agent/extensions/rp-native-tools-lock/rp-native-tools-lock.json";
 
 					if (ctx.hasUI) {
@@ -337,7 +344,7 @@ export default function rpNativeToolsLock(pi: ExtensionAPI): void {
 			block: true,
 			reason:
 				`rp-tools-lock (${state.mode}${suffix}): native tool "${event.toolName}" is disabled. ` +
-				`Use RepoPrompt instead (tool: ${requiredTool}). ` +
+				`Use RepoPrompt CE instead (tool: ${requiredTool}). ` +
 				`You can disable this lock with /rp-tools-lock off.`,
 		};
 	});

--- a/packages/pi-plan-modus/README.md
+++ b/packages/pi-plan-modus/README.md
@@ -1,10 +1,10 @@
 # Plan Modus for Pi (`pi-plan-modus`)
 
-Read-only exploration sandbox for Pi with RepoPrompt-aware write blocking. When enabled, plan mode removes Pi-native write tools from the active Pi tool list and blocks write-capable bash and RepoPrompt operations while leaving other available tools alone.
+Read-only exploration sandbox for Pi with RepoPrompt CE-aware write blocking. When enabled, plan mode removes Pi-native write tools from the active Pi tool list and blocks write-capable bash and RepoPrompt CE operations while leaving other available tools alone.
 
 Designed to be compatible with the [pi-repoprompt-mcp](https://www.npmjs.com/package/pi-repoprompt-mcp) and [pi-repoprompt-cli](https://www.npmjs.com/package/pi-repoprompt-cli) extensions. When any of these are active, plan mode blocks their write-capable operations (`apply_edits`, `file_actions`, file create/delete/move) while keeping read operations available.
 
-Based on the [plan-mode example](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/examples/extensions/plan-mode) from pi-mono, with additions for RepoPrompt integration and bash AST analysis.
+Based on the [plan-mode example](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent/examples/extensions/plan-mode) from pi-mono, with additions for RepoPrompt CE integration and bash AST analysis.
 
 ## Install
 
@@ -42,8 +42,8 @@ From the dot314 git bundle (filtered install):
 |---|---|
 | Native tools | `edit`, `write` |
 | Bash | Destructive commands (rm, mv, cp, mkdir, git commit, ...), write redirects (`>`, `>>`), editors (vim, nano, code) |
-| RepoPrompt MCP (`rp`) | `apply_edits`, `file_actions` |
-| RepoPrompt CLI (`rp_exec`, `rp-cli`) | `edit`, `file create/delete/move`, interactive REPL (`-i`) |
+| RepoPrompt CE MCP (`rp`) | `apply_edits`, `file_actions` |
+| RepoPrompt CE CLI (`rp_exec`, `rpce-cli`) | `edit`, `file create/delete/move`, interactive REPL (`-i`) |
 
 Read-only operations remain available across all layers: `read_file`, `get_file_tree`, `file_search`, `get_code_structure`, `git status/log/diff/show`, etc.
 

--- a/packages/pi-plan-modus/package.json
+++ b/packages/pi-plan-modus/package.json
@@ -1,8 +1,16 @@
 {
   "name": "pi-plan-modus",
-  "version": "0.2.5",
-  "description": "Read-only plan mode with RepoPrompt-aware write blocking; restricts tools, bash commands, and RepoPrompt operations (MCP + CLI) to read-only access",
-  "keywords": ["pi-package", "pi", "pi-coding-agent", "plan-mode", "read-only", "repoprompt"],
+  "version": "0.2.6",
+  "description": "Read-only plan mode with RepoPrompt-aware write blocking; restricts tools, bash commands, and RepoPrompt CE operations (MCP + CLI) to read-only access",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "plan-mode",
+    "read-only",
+    "repoprompt",
+    "repoprompt-ce"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,7 +22,9 @@
   },
   "homepage": "https://github.com/w-winter/dot314#readme",
   "pi": {
-    "extensions": ["extensions/plan-mode.ts"]
+    "extensions": [
+      "extensions/plan-mode.ts"
+    ]
   },
   "dependencies": {
     "just-bash": "^2.10.0"
@@ -26,11 +36,23 @@
   "scripts": {
     "prepack": "node ../../scripts/pi-package-prepack.mjs"
   },
-  "files": ["extensions/**", "README.md", "LICENSE", "THIRD-PARTY-NOTICES.md", "package.json"],
+  "files": [
+    "extensions/**",
+    "README.md",
+    "LICENSE",
+    "THIRD-PARTY-NOTICES.md",
+    "package.json"
+  ],
   "dot314Prepack": {
     "copy": [
-      { "from": "../../extensions/plan-mode.ts", "to": "extensions/plan-mode.ts" },
-      { "from": "../../LICENSE", "to": "LICENSE" }
+      {
+        "from": "../../extensions/plan-mode.ts",
+        "to": "extensions/plan-mode.ts"
+      },
+      {
+        "from": "../../LICENSE",
+        "to": "LICENSE"
+      }
     ]
   }
 }

--- a/packages/pi-repoprompt-cli/README.md
+++ b/packages/pi-repoprompt-cli/README.md
@@ -1,16 +1,16 @@
-# RepoPrompt CLI bridge for Pi (`pi-repoprompt-cli`)
+# RepoPrompt CE CLI bridge for Pi (`pi-repoprompt-cli`)
 
 > **⚠ Deprecated and not supported for Pi versions >0.64.0.**  Consider instead using [`pi-repoprompt-mcp`](https://www.npmjs.com/package/pi-repoprompt-mcp), which offers everything this extension has and several more reliability and QoL features, with none of the extra token overheads MCP tools typically entail.
 
-I recommend exploring the RepoPrompt CLI more from the angle of an agent skill for writing scripts that invoke rp-cli, while using repoprompt-mcp for Pi-RepoPrompt integration.
+I recommend exploring the RepoPrompt CE CLI more from the angle of an agent skill for writing scripts that invoke rpce-cli, while using repoprompt-mcp for Pi-RepoPrompt integration.
 
 ---
 
-Integrates RepoPrompt with Pi via RepoPrompt's `rp-cli` executable.
+Integrates RepoPrompt with Pi via RepoPrompt CE's `rpce-cli` executable.
 
 Provides two tools:
-- `rp_bind` — bind a RepoPrompt window + compose tab (routing)
-- `rp_exec` — run `rp-cli -e <cmd>` against that binding (quiet defaults + output truncation)
+- `rp_bind` — bind a RepoPrompt CE window + compose tab (routing)
+- `rp_exec` — run `rpce-cli -e <cmd>` against that binding (quiet defaults + output truncation)
 
 Optional:
 - Diff blocks in `rp_exec` output use `delta` when installed (honoring the user's global git/delta color config), with graceful fallback otherwise
@@ -51,7 +51,7 @@ Add to `~/.pi/agent/settings.json` (or replace an existing unfiltered `git:githu
 
 ## Requirements
 
-- `rp-cli` must be installed and available on `PATH`
+- `rpce-cli` must be installed and available on `PATH`
 
 ## Configuration
 
@@ -71,11 +71,11 @@ Create `~/.pi/agent/extensions/repoprompt-cli/config.json`:
 
 ## Quick start
 
-1) Find your RepoPrompt window + tab (from a terminal):
+1) Find your RepoPrompt CE window + tab (from a terminal):
 
 ```bash
-rp-cli -e windows
-rp-cli -e "workspace tabs"
+rpce-cli -e windows
+rpce-cli -e "workspace tabs"
 ```
 
 2) Bind inside Pi:
@@ -84,7 +84,7 @@ rp-cli -e "workspace tabs"
 /rpbind 3 Compose
 ```
 
-3) Instruct the agent to use RepoPrompt via the `rp_exec` tool, for example:
+3) Instruct the agent to use RepoPrompt CE via the `rp_exec` tool, for example:
 
 ```text
 Use rp_exec with cmd: "get_file_tree type=files max_depth=4".

--- a/packages/pi-repoprompt-cli/package.json
+++ b/packages/pi-repoprompt-cli/package.json
@@ -1,8 +1,14 @@
 {
   "name": "pi-repoprompt-cli",
-  "version": "0.3.2",
-  "description": "Integrates RepoPrompt with Pi via RepoPrompt's `rp-cli` executable",
-  "keywords": ["pi-package", "pi", "pi-coding-agent", "repoprompt"],
+  "version": "0.4.0",
+  "description": "Integrates RepoPrompt CE with Pi via RepoPrompt CE's `rpce-cli` executable",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "repoprompt",
+    "repoprompt-ce"
+],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,7 +20,9 @@
   },
   "homepage": "https://github.com/w-winter/dot314#readme",
   "pi": {
-    "extensions": ["extensions/repoprompt-cli/index.ts"]
+    "extensions": [
+      "extensions/repoprompt-cli/index.ts"
+    ]
   },
   "dependencies": {
     "diff": "^7.0.0",
@@ -28,7 +36,12 @@
   "scripts": {
     "prepack": "node ../../scripts/pi-package-prepack.mjs"
   },
-  "files": ["extensions/**", "README.md", "LICENSE", "package.json"],
+  "files": [
+    "extensions/**",
+    "README.md",
+    "LICENSE",
+    "package.json"
+  ],
   "dot314Prepack": {
     "copy": [
       {
@@ -59,7 +72,10 @@
         "from": "../../extensions/repoprompt-cli/readcache",
         "to": "extensions/repoprompt-cli/readcache"
       },
-      { "from": "../../LICENSE", "to": "LICENSE" }
+      {
+        "from": "../../LICENSE",
+        "to": "LICENSE"
+      }
     ]
   }
 }

--- a/packages/pi-repoprompt-mcp/README.md
+++ b/packages/pi-repoprompt-mcp/README.md
@@ -1,8 +1,10 @@
-# RepoPrompt MCP for Pi (`pi-repoprompt-mcp`)
+# RepoPrompt CE MCP for Pi (`pi-repoprompt-mcp`)
 
-This extension provides a single tool (`rp`) that exposes RepoPrompt MCP tools to Pi, includes branch-safe window and tab binding (auto-detect and bind to window by `cwd`, auto-bind to safe tab, persist and restore across sessions and session tree nodes, and interactive selection of windows and tabs) and batches of read files (automatically selected as context in the RepoPrompt desktop app), renders RepoPrompt tool outputs (syntax + diff highlighting), and applies guardrails for destructive operations.
+This extension only applies to the Community Edition of RepoPrompt (RepoPrompt CE) and older versions in the repository work with the RepoPrompt Classic Edition).
 
-The extension's window- and tab-related management features allow a workflow where new Pi sessions automatically attach to the required workspace and tab without clobbering your, or other agents', parallel usage of RepoPrompt.  Because it recovers the window, tab, and auto-selected read-files context when you rewind via `/tree` or restore a session, all the context the agent has built up (and automatically selected in the RepoPrompt app) by reading files and slices up to that point always remains available in the app for RP Chat (see `/rp oracle` below) or external "oracle" (e.g. GPT-x Pro) use cases.  Recovery is based on the required root(s) of the saved selection state, so it can reattach to any open workspace that already contains those roots rather than requiring the original workspace name; if multiple open workspaces satisfy that requirement and `cwd` does not disambiguate them, then you should re-bind with `/rp bind`.
+This extension provides a single tool (`rp`) that exposes RepoPrompt CE MCP tools to Pi, includes branch-safe window and tab binding (auto-detect and bind to window by `cwd`, auto-bind to safe tab, persist and restore across sessions and session tree nodes, and interactive selection of windows and tabs) and batches of read files (automatically selected as context in the RepoPrompt CE desktop app), renders RepoPrompt CE tool outputs (syntax + diff highlighting), and applies guardrails for destructive operations.
+
+The extension's window- and tab-related management features allow a workflow where new Pi sessions automatically attach to the required workspace and tab without clobbering your, or other agents', parallel usage of RepoPrompt CE.  Because it recovers the window, tab, and auto-selected read-files context when you rewind via `/tree` or restore a session, all the context the agent has built up (and automatically selected in the RepoPrompt CE app) by reading files and slices up to that point always remains available in the app for RP Chat (see `/rp oracle` below) or external "oracle" (e.g. GPT-x Pro) use cases.  Recovery is based on the required root(s) of the saved selection state, so it can reattach to any open workspace that already contains those roots rather than requiring the original workspace name; if multiple open workspaces satisfy that requirement and `cwd` does not disambiguate them, then you should re-bind with `/rp bind`.
 
 ## Installation
 
@@ -34,7 +36,7 @@ Add to `~/.pi/agent/settings.json` (or replace an existing unfiltered `git:githu
 
 ### Window and tab binding
 
-- Auto-binds to the RepoPrompt window that matches `process.cwd()` (by workspace roots, resolving symlinks to their real paths before matching)
+- Auto-binds to the RepoPrompt CE window that matches `process.cwd()` (by workspace roots, resolving symlinks to their real paths before matching)
   - If multiple windows match, you're prompted to pick one
   - Window binding is (optionally) persisted across session reloads and session tree nodes
 - If a bound window has an existing tab with zero selected files and no chats, the extension binds to that tab; otherwise it provisions a new tab and binds to that
@@ -42,19 +44,19 @@ Add to `~/.pi/agent/settings.json` (or replace an existing unfiltered `git:githu
 - User-driven binding via `/rp bind` (windows) or `/rp tab` (tabs); agents can use `rp({ bind: ... })`
 - In addition to window bindings, tab bindings and auto-selected read-files context is stored and automatically recovered across node rewinds via `/tree`, different sessions (e.g., created via `/fork`), and resumed sessions
 
-Forked sessions inherit the parent session-plus-node's window, tab, and auto-selected context snapshot at the fork point (unless you rewind in the forked session and switch window/tab/etc.), then can diverge independently as later reads or manual tab switches are performed in the child session.  Binding is non-invasive, in that it doesn't change RepoPrompt's globally active window, and automatic tab provisioning uses background tabs (`focus=false`) without stealing UI focus.  This is to prevent interference when multiple agents (or your manual usage of RepoPrompt in parallel to a Pi session) are using this extension and need to target different windows or tabs simultaneously.
+Forked sessions inherit the parent session-plus-node's window, tab, and auto-selected context snapshot at the fork point (unless you rewind in the forked session and switch window/tab/etc.), then can diverge independently as later reads or manual tab switches are performed in the child session.  Binding is non-invasive, in that it doesn't change RepoPrompt CE's globally active window, and automatic tab provisioning uses background tabs (`focus=false`) without stealing UI focus.  This is to prevent interference when multiple agents (or your manual usage of RepoPrompt CE in parallel to a Pi session) are using this extension and need to target different windows or tabs simultaneously.
 
 ### Output rendering
 
 - Syntax highlighting for code blocks and codemaps in `read_file`, and for code blocks in outputs of `apply_edits`, `file_actions create/delete`, and `git`
-- Common non-mutating RepoPrompt actions (`read_file`, `file_search`, `get_file_tree`, `get_code_structure`, `workspace_context`, routing helpers like `manage_workspaces`, and control/discovery actions like `windows`/`bind`/`status`/`search`/`describe`) get concise request-driven call/result summaries in collapsed mode.  The call line carries intent while the result line carries outcome, so the transcript stays compact without echoing the same label twice.  These summaries are derived from the arguments Pi sent, not by parsing RepoPrompt's prose output, and unknown tools fall back to normal collapsed rendering
+- Common non-mutating RepoPrompt CE actions (`read_file`, `file_search`, `get_file_tree`, `get_code_structure`, `workspace_context`, routing helpers like `manage_workspaces`, and control/discovery actions like `windows`/`bind`/`status`/`search`/`describe`) get concise request-driven call/result summaries in collapsed mode.  The call line carries intent while the result line carries outcome, so the transcript stays compact without echoing the same label twice.  These summaries are derived from the arguments Pi sent, not by parsing RepoPrompt CE's prose output, and unknown tools fall back to normal collapsed rendering
 
 <p align="center">
   <img width="270" height="936" alt="Collapsed call/result summaries" src="https://raw.githubusercontent.com/w-winter/dot314/main/packages/pi-repoprompt-mcp/docs/images/collapsed-summaries.png" />
 </p>
 
-- RepoPrompt `apply_edits` calls are forwarded with `verbose: true` by default, while the returned diff is normalized into `details.diff` and presented to the agent as a terse summary.  The same is done for `file_actions create/delete` outputs, so you see all edited/created/deleted LOC with rich rendering but the extension prevents the context window from getting bloated by round-tripping tool I/O tokens
-- Adaptive diff rendering for RepoPrompt `git` and `apply_edits` outputs by default (`diffViewMode: "auto"` picks split, unified, compact, or summary at render time based on pane width).  This uses the active Pi theme's `toolDiffAdded`, `toolDiffRemoved`, and `toolDiffContext` colors (typically mapped to chosen hues for green and red), and its visual design and rendering logic are indebted to [MasuRii/pi-tool-display](https://github.com/MasuRii/pi-tool-display).  Two different examples at different pane widths:
+- RepoPrompt CE `apply_edits` calls are forwarded with `verbose: true` by default, while the returned diff is normalized into `details.diff` and presented to the agent as a terse summary.  The same is done for `file_actions create/delete` outputs, so you see all edited/created/deleted LOC with rich rendering but the extension prevents the context window from getting bloated by round-tripping tool I/O tokens
+- Adaptive diff rendering for RepoPrompt CE `git` and `apply_edits` outputs by default (`diffViewMode: "auto"` picks split, unified, compact, or summary at render time based on pane width).  This uses the active Pi theme's `toolDiffAdded`, `toolDiffRemoved`, and `toolDiffContext` colors (typically mapped to chosen hues for green and red), and its visual design and rendering logic are indebted to [MasuRii/pi-tool-display](https://github.com/MasuRii/pi-tool-display).  Two different examples at different pane widths:
 
 <p align="center">
   <img width="1027" height="256" alt="Split diff rendering" src="https://raw.githubusercontent.com/w-winter/dot314/main/packages/pi-repoprompt-mcp/docs/images/diff-split.png" />
@@ -74,23 +76,23 @@ Forked sessions inherit the parent session-plus-node's window, tab, and auto-sel
 
 ## Requirements
 
-- RepoPrompt MCP server configured and reachable (stdio transport)
+- RepoPrompt CE MCP server configured and reachable (stdio transport)
   - If the server is not configured/auto-detected, the extension will still load, but `rp(...)` will error until you configure it
-- `rp-cli` available in `PATH` is recommended (used as a fallback for window discovery)
+- `rpce-cli` available in `PATH` is recommended (used as a fallback for window discovery)
 
 ### Compatibility notes
 
-This extension tries to be tolerant of **tool name prefixing** (e.g. `RepoPrompt_list_windows` vs `list_windows`), but it is still dependent on a small set of capabilities and their semantics remaining reasonably stable across RepoPrompt versions:
+This extension tries to be tolerant of **tool name prefixing** (e.g. `RepoPrompt_list_windows` vs `list_windows`), but it is still dependent on a small set of capabilities and their semantics remaining reasonably stable across RepoPrompt CE versions:
 
 - **Window discovery**: `list_windows`
-  - If `list_windows` is not exposed by the MCP server, the extension falls back to `rp-cli -e 'windows'`
+  - If `list_windows` is not exposed by the MCP server, the extension falls back to `rpce-cli -e 'windows'`
   - If neither is available, window listing/binding features will be limited
 - **Workspace root discovery (auto-bind by cwd)**: `get_file_tree` with `{ type: "roots" }` (scoped by `_windowID`)
   - If unavailable (or if parameters/semantics change), auto-binding may be disabled or less accurate
 - Selection summary: `manage_selection` with `{ op: "get", view: "files" }` and `{ op: "get", view: "summary" }`
   - If these are unavailable (or if parameters/semantics change), the status output may omit file/token counts
 
-If RepoPrompt renames/removes these tools or changes their required parameters/output formats, this extension may need updates
+If RepoPrompt CE renames/removes these tools or changes their required parameters/output formats, this extension may need updates
 
 ## Usage
 
@@ -102,14 +104,14 @@ If RepoPrompt renames/removes these tools or changes their required parameters/o
   <img width="210" alt="Status display" src="https://raw.githubusercontent.com/w-winter/dot314/main/packages/pi-repoprompt-mcp/docs/images/status.png" />
 </p>
 
-- `/rp windows` — list available RepoPrompt windows
-- `/rp bind` — interactive workflow for choosing the RepoPrompt window
+- `/rp windows` — list available RepoPrompt CE windows
+- `/rp bind` — interactive workflow for choosing the RepoPrompt CE window
 - `/rp bind <id> [tab]` — direct option if you already know the target window id (and optionally an exact tab name or tab id); when `[tab]` is omitted, the extension restores the branch's tab for that window or provisions a fresh background tab once
 - `/rp tab` — interactive tab picker for the current bound window, with `Create new tab` as the first option followed by existing tab names
 - `/rp tab new` — create and bind a fresh tab on the current bound window
 - `/rp tab <name-or-id>` — bind an existing tab on the current bound window by name or id
-- `/rp oracle [--mode <chat|plan|edit|review>] [--name <chat name>] [--continue|--chat-id <id>] <message>` — ask RepoPrompt chat with current selection context.  If `--mode` not specified, uses `oracleDefaultMode` config.
-- `/rp reconnect` — reconnect to RepoPrompt
+- `/rp oracle [--mode <chat|plan|edit|review>] [--name <chat name>] [--continue|--chat-id <id>] <message>` — ask RepoPrompt CE chat with current selection context.  If `--mode` not specified, uses `oracleDefaultMode` config.
+- `/rp reconnect` — reconnect to RepoPrompt CE
 
 ### Tool: `rp`
 
@@ -119,10 +121,10 @@ Examples:
 // Status (connection + binding)
 rp({ })
 
-// List windows (best-effort; uses MCP tool if available, otherwise rp-cli)
+// List windows (best-effort; uses MCP tool if available, otherwise rpce-cli)
 rp({ windows: true })
 
-// Bind to a specific window (does not change RepoPrompt active window)
+// Bind to a specific window (does not change RepoPrompt CE active window)
 rp({ bind: { window: 3 } })
 
 // Bind to an exact tab in that window
@@ -132,7 +134,7 @@ rp({ bind: { window: 3, tab: "T2" } })
 rp({ search: "file" })
 rp({ describe: "apply_edits" })
 
-// Call a RepoPrompt tool (binding args are injected automatically)
+// Call a RepoPrompt CE tool (binding args are injected automatically)
 rp({ call: "read_file", args: { path: "src/main.ts" } })
 
 // Edit confirmation gate (only required if confirmEdits=true in config)
@@ -177,7 +179,7 @@ Create `~/.pi/agent/extensions/repoprompt-mcp.json`:
 }
 ```
 
-`collapsedMaxLines` controls how many rendered lines of RepoPrompt tool output Pi shows before the result is expanded for the generic fallback path.  In addition, the extension now emits hand-authored one-line or two-line collapsed summaries for common non-mutating actions like `read_file`, `file_search`, `get_file_tree`, `get_code_structure`, `workspace_context`, `windows`, `bind`, and `status`; these are derived from Pi's own request metadata rather than RepoPrompt's returned prose.  Unknown or unsupported tools still fall back to the normal `collapsedMaxLines` behavior.  LOC-changing operations are the other exception: verbose RepoPrompt `apply_edits` and rendered `file_actions create/delete` results ignore `collapsedMaxLines` once normalized into `details.diff`, so the full rendered code changes remain visible.
+`collapsedMaxLines` controls how many rendered lines of RepoPrompt CE tool output Pi shows before the result is expanded for the generic fallback path.  In addition, the extension now emits hand-authored one-line or two-line collapsed summaries for common non-mutating actions like `read_file`, `file_search`, `get_file_tree`, `get_code_structure`, `workspace_context`, `windows`, `bind`, and `status`; these are derived from Pi's own request metadata rather than RepoPrompt CE's returned prose.  Unknown or unsupported tools still fall back to the normal `collapsedMaxLines` behavior.  LOC-changing operations are the other exception: verbose RepoPrompt CE `apply_edits` and rendered `file_actions create/delete` results ignore `collapsedMaxLines` once normalized into `details.diff`, so the full rendered code changes remain visible.
 
 Options:
 
@@ -186,22 +188,22 @@ Options:
 | `command` | auto-detect | MCP server command |
 | `args` | `[]` | MCP server args |
 | `env` | unset | Extra environment variables for the MCP server |
-| `toolCallTimeoutMs` | `5400000` | MCP tool call timeout in milliseconds for RepoPrompt tools like `context_builder` and `oracle_send` (90 minutes by default) |
+| `toolCallTimeoutMs` | `5400000` | MCP tool call timeout in milliseconds for RepoPrompt CE tools like `context_builder` and `oracle_send` (90 minutes by default) |
 | `autoBindOnStart` | `true` | Auto-detect and bind on session start, then reconcile the branch-safe tab for the chosen window |
 | `persistBinding` | `true` | Persist window and tab bindings in Pi session history for branch-safe replay |
 | `confirmDeletes` | `true` | Block delete operations unless `allowDelete: true` |
 | `confirmEdits` | `false` | Block edit-like operations unless `confirmEdits: true` |
-| `readcacheReadFile` | `false` | Enable [pi-readcache](https://github.com/Gurpartap/pi-readcache)-like caching for RepoPrompt `read_file` calls (returns unchanged markers/diffs on repeat reads to save on tokens and prevent context bloat) |
+| `readcacheReadFile` | `false` | Enable [pi-readcache](https://github.com/Gurpartap/pi-readcache)-like caching for RepoPrompt CE `read_file` calls (returns unchanged markers/diffs on repeat reads to save on tokens and prevent context bloat) |
 | `autoSelectReadSlices` | `true` | Automatically track `read_file` calls by adding slices/full-file selection via `manage_selection`, so `chat_send` (or a manually created chat in the RP app) uses everything the agent has read as context; these file/slice selections are **branch-safe** across `/tree` rewinds and `/fork`ed session branches via extension-owned snapshot replay |
 | `oracleDefaultMode` | `"chat"` | Default mode for `/rp oracle` when `--mode` is omitted (`chat`, `plan`, `edit`, or `review`) |
 | `collapsedMaxLines` | `3` | Lines shown in collapsed view |
-| `diffViewMode` | `"auto"` | Diff layout for RepoPrompt `git` / `apply_edits` fenced diff output (`auto`, `split`, `unified`) |
+| `diffViewMode` | `"auto"` | Diff layout for RepoPrompt CE `git` / `apply_edits` fenced diff output (`auto`, `split`, `unified`) |
 | `diffSplitMinWidth` | `120` | Minimum render width before `diffViewMode: "auto"` uses split diff layout |
 | `suppressHostDisconnectedLog` | `true` | Filter noisy stderr from macOS `repoprompt-mcp` (disconnect/retry bootstrap logs) |
-| `autoLaunchApp` | `false` | Auto-launch the RepoPrompt app when the MCP server is unreachable at startup |
+| `autoLaunchApp` | `false` | Auto-launch the RepoPrompt CE app when the MCP server is unreachable at startup |
 | `appPath` | inferred | Explicit path to `Repo Prompt.app`; if omitted, inferred from the `.app` ancestor of `command` |
 
-Automatic tab restoration and provisioning is driven by `autoBindOnStart` and `persistBinding`; there is no separate tab-only configuration surface. Adaptive diff layout applies only to RepoPrompt `git` and `apply_edits` outputs that arrive as fenced `diff` blocks; other rendered output stays on the existing text-based path.
+Automatic tab restoration and provisioning is driven by `autoBindOnStart` and `persistBinding`; there is no separate tab-only configuration surface. Adaptive diff layout applies only to RepoPrompt CE `git` and `apply_edits` outputs that arrive as fenced `diff` blocks; other rendered output stays on the existing text-based path.
 
 Note: when `readcacheReadFile` is enabled, the extension may persist UTF-8 file snapshots to an on-disk content-addressed store under
 `<repo-root>/.pi/readcache/objects` to compute diffs/unchanged markers across calls. Common secret filenames (e.g. `.env*`, `*.pem`) are excluded,
@@ -214,27 +216,27 @@ but this is best-effort
 
 ## Troubleshooting
 
-### "Not connected to RepoPrompt"
-- Ensure RepoPrompt is running
+### "Not connected to RepoPrompt CE"
+- Ensure RepoPrompt CE is running
 - Verify the MCP server command in config
 - Run `/rp reconnect`
 
-### Pi becomes unresponsive after closing/restarting RepoPrompt
-If the RepoPrompt MCP server stops responding (for example, if the RepoPrompt app is closed while Pi stays open), tool calls may time out. When that happens, the extension will drop the connection and you can recover with `/rp reconnect`.
+### Pi becomes unresponsive after closing/restarting RepoPrompt CE
+If the RepoPrompt CE MCP server stops responding (for example, if the RepoPrompt CE app is closed while Pi stays open), tool calls may time out. When that happens, the extension will drop the connection and you can recover with `/rp reconnect`.
 
-If RepoPrompt is not running when Pi starts, the extension auto-pauses itself after a quick connection timeout.  While paused, the `rp` tool returns a short error directing the agent to use native tools.  Run `/rp reconnect` once RepoPrompt is open to resume, and the agent will be notified that `rp` is available again.
+If RepoPrompt CE is not running when Pi starts, the extension auto-pauses itself after a quick connection timeout.  While paused, the `rp` tool returns a short error directing the agent to use native tools.  Run `/rp reconnect` once RepoPrompt CE is open to resume, and the agent will be notified that `rp` is available again.
 
-If `autoLaunchApp` is enabled, the extension will try to open the RepoPrompt app automatically before pausing.  The app path is inferred from the `command` config (e.g. `/Applications/Repo Prompt.app/Contents/MacOS/repoprompt-mcp` → `/Applications/Repo Prompt.app`), or you can set `appPath` explicitly.  After launching, the extension waits a few seconds and retries the connection once; if that also fails, it auto-pauses as usual.
+If `autoLaunchApp` is enabled, the extension will try to open the RepoPrompt CE app automatically before pausing.  The app path is inferred from the `command` config (e.g. `/Applications/RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp` → `/Applications/RepoPrompt CE.app`), or you can set `appPath` explicitly.  After launching, the extension waits a few seconds and retries the connection once; if that also fails, it auto-pauses as usual.
 
 ### "No matching window found"
-- Your `cwd` may not match any RepoPrompt workspace root
+- Your `cwd` may not match any RepoPrompt CE workspace root
 - Use `/rp windows` to list windows
 - Use `/rp bind` to pick one
 
 ### Window listing doesn't work
-- If the MCP server does not expose a `list_windows` tool, this extension uses `rp-cli -e 'windows'`
-- Make sure `rp-cli` is installed and on your `PATH`
-- If RepoPrompt is in single-window mode, `rp-cli -e 'windows'` may report single-window mode
+- If the MCP server does not expose a `list_windows` tool, this extension uses `rpce-cli -e 'windows'`
+- Make sure `rpce-cli` is installed and on your `PATH`
+- If RepoPrompt CE is in single-window mode, `rpce-cli -e 'windows'` may report single-window mode
 
 ### Delete operation blocked
 - Pass `allowDelete: true` on the `rp` call

--- a/packages/pi-repoprompt-mcp/package.json
+++ b/packages/pi-repoprompt-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-repoprompt-mcp",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "A token-efficient RepoPrompt integration for Pi with automated and branch-safe workspace management",
   "keywords": ["pi-package", "pi", "pi-coding-agent", "repoprompt", "mcp"],
   "license": "MIT",

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,17 +1,17 @@
 # Prompts
 
-## For [RepoPrompt](https://repoprompt.com/docs) MCP tools
+## For [RepoPrompt CE](https://repoprompt.com/docs) MCP tools
 
 - ● [`rp-plan.md`](rp-plan.md)
   - Planning-mode protocol: quick scan → `context_builder` → resolve unknowns (facts→chat→user) → produce a decision-complete plan
   - Asks the user only high-leverage questions (batched, budgeted), records defaults/assumptions
 
 - ● [`rp-review-chat.md`](rp-review-chat.md)
-  - Sends a RepoPrompt `chat_send` with `mode="review"` to review diffs
-  - Token-efficient: infers diff scope (staged/unstaged/range) via name-only commands, lets RepoPrompt supply diffs automatically
+  - Sends a RepoPrompt CE `chat_send` with `mode="review"` to review diffs
+  - Token-efficient: infers diff scope (staged/unstaged/range) via name-only commands, lets RepoPrompt CE supply diffs automatically
 
 - ● [`rp-address-review.md`](rp-address-review.md)
   - Reads review feedback files, addresses all issues, appends completed work to a plan/log/todos file
   - Uses `context_builder` when reviewer suggestions need clarification
 
-Related: `skills/repoprompt-tool-guidance-refresh/rp-cli-prompts/` contains CLI-specific prompt variants for use with the `repoprompt-cli` extension.
+Related: `skills/repoprompt-tool-guidance-refresh/rp-cli-prompts/` contains CLI-specific prompt variants for use with the deprecated RepoPrompt Classic Edition `repoprompt-cli` extension.

--- a/skills/README.markdown
+++ b/skills/README.markdown
@@ -3,14 +3,14 @@
 ## New or locally modified
 
 - ● [`repoprompt-tool-guidance-refresh/`](repoprompt-tool-guidance-refresh/)
-  - Two-phase workflow for updating RepoPrompt tool guidance across version upgrades:
-    1. Invoke **before** upgrading → captures baseline (`rp-cli -l`, `rp-cli --help`)
+  - Two-phase workflow for updating RepoPrompt CE tool guidance across version upgrades:
+    1. Invoke **before** upgrading → captures baseline (`rpce-cli -l`, `rpce-cli --help`)
     2. Invoke **after** upgrading → detects changes, generates diffs, updates docs
   - Contents:
     - [`SKILL.md`](repoprompt-tool-guidance-refresh/SKILL.md)
-    - [`scripts/track-rp-version.sh`](repoprompt-tool-guidance-refresh/scripts/track-rp-version.sh) — version detection and diff generation of RepoPrompt MCP tool definitions and of the RepoPrompt CLI
+    - [`scripts/track-rp-version.sh`](repoprompt-tool-guidance-refresh/scripts/track-rp-version.sh) — version detection and diff generation of RepoPrompt CE MCP tool definitions and of the RepoPrompt CE CLI
     - [`rp-tool-defs/`](repoprompt-tool-guidance-refresh/rp-tool-defs/) — captured snapshots and diffs
-    - [`rp-cli-prompts/`](repoprompt-tool-guidance-refresh/rp-cli-prompts/) — CLI-specific prompts maintained by this skill
+    - [`rp-cli-prompts/`](repoprompt-tool-guidance-refresh/rpce-cli-prompts/) — RepoPrompt CE CLI-specific prompts maintained by this skill
 
 - ◐ [`text-search/`](text-search/)
   - Search indexed text corpora (sessions, docs, logs) using qmd. Use instead of grep.

--- a/skills/repoprompt-tool-guidance-refresh/SKILL.md
+++ b/skills/repoprompt-tool-guidance-refresh/SKILL.md
@@ -1,7 +1,7 @@
 ---
 disable-model-invocation: true
 name: repoprompt-tool-guidance-refresh
-description: Update RepoPrompt tool guidance based on MCP/CLI changes across versions. Two-phase workflow - invoke BEFORE upgrading (--pre), then AFTER upgrading (--post). Uses `~/.pi/agent/skills/repoprompt-tool-guidance-refresh/scripts/track-rp-version.sh` to detect and diff changes (outputs to `~/.pi/agent/skills/repoprompt-tool-guidance-refresh/rp-tool-defs/`).
+description: Update RepoPrompt CE tool guidance based on MCP/CLI changes across versions. Two-phase workflow - invoke BEFORE upgrading (--pre), then AFTER upgrading (--post). Uses `~/.pi/agent/skills/repoprompt-tool-guidance-refresh/scripts/track-rp-version.sh` to detect and diff changes (outputs to `~/.pi/agent/skills/repoprompt-tool-guidance-refresh/rp-tool-defs/`).
 ---
 
 # Workflow
@@ -13,7 +13,7 @@ This skill has two invocation modes depending on where you are in the upgrade cy
 - Script: `~/.pi/agent/skills/repoprompt-tool-guidance-refresh/scripts/track-rp-version.sh`
 - Output directory: `~/.pi/agent/skills/repoprompt-tool-guidance-refresh/rp-tool-defs/`
 
-## Phase A — Pre-Upgrade (invoke BEFORE updating RepoPrompt)
+## Phase A — Pre-Upgrade (invoke BEFORE updating RepoPrompt CE)
 
 1. Run the version tracking script:
    ```bash
@@ -25,14 +25,14 @@ This skill has two invocation modes depending on where you are in the upgrade cy
    - `~/.pi/agent/skills/repoprompt-tool-guidance-refresh/rp-tool-defs/`
 
    Files created/updated:
-   - `.baseline_version` — the baseline `rp-cli` version
-   - `rpcli-help__{VERSION}.txt` — output of `rp-cli --help`
-   - `rpcli-l__{VERSION}.txt` — output of `rp-cli -l`
+   - `.baseline_version` — the baseline `rpce-cli` version
+   - `rpcli-help__{VERSION}.txt` — output of `rpce-cli --help`
+   - `rpcli-l__{VERSION}.txt` — output of `rpce-cli -l`
 
 3. **Stop here.** Tell the user:
-   > ✓ Baseline captured at v{VERSION}. Go update RepoPrompt, then re-invoke this skill.
+   > ✓ Baseline captured at v{VERSION}. Go update RepoPrompt CE, then re-invoke this skill.
 
-## Phase B — Post-Upgrade (invoke AFTER updating RepoPrompt)
+## Phase B — Post-Upgrade (invoke AFTER updating RepoPrompt CE)
 
 1. Run the version tracking script:
    ```bash
@@ -45,8 +45,8 @@ This skill has two invocation modes depending on where you are in the upgrade cy
 
    Files created/updated:
    - `rpcli-help__{NEW_VERSION}.txt` / `rpcli-l__{NEW_VERSION}.txt` — new snapshots
-   - `rpcli-help__{NEW_VERSION}.diff` — changes in `rp-cli --help`
-   - `rpcli-l__{NEW_VERSION}.diff` — changes in `rp-cli -l` (MCP tool definitions)
+   - `rpcli-help__{NEW_VERSION}.diff` — changes in `rpce-cli --help`
+   - `rpcli-l__{NEW_VERSION}.diff` — changes in `rpce-cli -l` (MCP tool definitions)
 
 3. If no changes detected in the diffs, tell the user and stop:
    > ✓ No MCP/CLI tool changes detected. Documentation is current.
@@ -95,7 +95,7 @@ Only update documentation for changes that affect levers you directly use:
 - Changed parameters, modes, or behaviors
 
 Ignore changes that only affect:
-- RepoPrompt desktop app UI (without MCP/CLI changes)
+- RepoPrompt CE desktop app UI (without MCP/CLI changes)
 - Integrations with other apps/harnesses (without MCP/CLI changes)
 - Internal implementation details not exposed via tools
 

--- a/skills/repoprompt-tool-guidance-refresh/rp-cli-prompts/rp-address-review-cli.md
+++ b/skills/repoprompt-tool-guidance-refresh/rp-cli-prompts/rp-address-review-cli.md
@@ -1,29 +1,29 @@
 ---
-description: Address issues surfaced by code review(s) and log work (rp-cli).  Argument hints — [plan||log||todos||tasks = <path-to-plan-or-tasks-log.md>] [reviews = <path_to_review_feedback.md> <possible_additional_path_to_extra_review_feedback.md> <...>]
+description: Address issues surfaced by code review(s) and log work (rpce-cli).  Argument hints — [plan||log||todos||tasks = <path-to-plan-or-tasks-log.md>] [reviews = <path_to_review_feedback.md> <possible_additional_path_to_extra_review_feedback.md> <...>]
 ---
 
 ARGUMENTS: $ARGUMENTS
 
 The executed tasks of plan/log/todos/tasks mentioned by the user in ARGUMENTS were reviewed by one or more panels of code reviewers. They gave the feedback logged in the one or more review feedback files mentioned by the user in ARGUMENTS.
 
-## Using rp-cli
+## Using rpce-cli
 
-Run RepoPrompt CLI commands like this:
+Run RepoPrompt CE CLI commands like this:
 
 ```bash
-rp-cli -e '<command>'
+rpce-cli -e '<command>'
 ```
 
 ### Important: use `rp_exec` if your harness is Pi:
 
-In the Pi coding agent harness, use `rp_exec` and treat snippets as the cmd string (drop the `rp-cli -e` prefix); only use `rp-cli -e` in a shell fallback.
+In the Pi coding agent harness, use `rp_exec` and treat snippets as the cmd string (drop the `rpce-cli -e` prefix); only use `rpce-cli -e` in a shell fallback.
 
 ## Protocol
 
 1. Read every (one or more) review feedback file that the user mentions in ARGUMENTS
 2. Address all issues mentioned in every review feedback file mentioned
-   - Use RepoPrompt context-building and planning commands when the reviewers' suggestions are not precise/thorough/clear enough
-     - `rp-cli -e 'builder "instructions" --response-type plan'` (rebuild context + get a plan)
+   - Use RepoPrompt CE context-building and planning commands when the reviewers' suggestions are not precise/thorough/clear enough
+     - `rpce-cli -e 'builder "instructions" --response-type plan'` (rebuild context + get a plan)
      - `plan "<question>"` / `chat "<question>"` for targeted follow-ups
      - If you ran `builder` and got a `chat_id`, continue the same thread with: `chat "<followup>" --chat-id <chat_id>`
 3. Update an Appendix section at the end of the user-mentioned plan/log/todos/tasks file that captures this additional work you've just done to address all those issues.  If such an Appendix doesn't exist, create it.

--- a/skills/repoprompt-tool-guidance-refresh/rp-cli-prompts/rp-review-chat-cli.md
+++ b/skills/repoprompt-tool-guidance-refresh/rp-cli-prompts/rp-review-chat-cli.md
@@ -1,32 +1,32 @@
 ---
-description: RepoPrompt diff review
+description: RepoPrompt CE diff review
 ---
 
-# Send RepoPrompt Chat in Review Mode (rp-cli)
+# Send RepoPrompt CE Chat in Review Mode (rpce-cli)
 
 Request: $ARGUMENTS
 
-Goal: send a RepoPrompt review chat using rp-cli (`mode="review"`) to review diffs, in a fast and token-efficient way, while optionally adding extra context files (even if unchanged) and passing user notes verbatim.
+Goal: send a RepoPrompt CE review chat using rpce-cli (`mode="review"`) to review diffs, in a fast and token-efficient way, while optionally adding extra context files (even if unchanged) and passing user notes verbatim.
 
-RepoPrompt `mode="review"`: analyzes code changes using git diffs of the selected files; it only sees the current selection/context.
+RepoPrompt CE `mode="review"`: analyzes code changes using git diffs of the selected files; it only sees the current selection/context.
 
 CRITICAL: Be swift and token-efficient
 - Do NOT run `git diff` to read diff contents
 - Do NOT paste any diff text into the chat message
 - Do NOT “line-by-line” review diff output in your own scratchpad
-- Rely on RepoPrompt review mode (with diffs enabled) to supply diffs for the selected files automatically
+- Rely on RepoPrompt CE review mode (with diffs enabled) to supply diffs for the selected files automatically
 
-## Using rp-cli
+## Using rpce-cli
 
-Run RepoPrompt CLI commands like this:
+Run RepoPrompt CE CLI commands like this:
 
 ```bash
-rp-cli -e '<command>'
+rpce-cli -e '<command>'
 ```
 
 ### Important: use `rp_exec` if your harness is Pi:
 
-In the Pi coding agent harness, use `rp_exec` and treat snippets as the cmd string (drop the `rp-cli -e` prefix); only use `rp-cli -e` in a shell fallback.
+In the Pi coding agent harness, use `rp_exec` and treat snippets as the cmd string (drop the `rpce-cli -e` prefix); only use `rpce-cli -e` in a shell fallback.
 
 ---
 
@@ -51,18 +51,18 @@ Prefer explicit user intent if present:
 - Also include any additional file paths mentioned in $ARGUMENTS that the user likely wants as guidance/context, even if unchanged.
 - Context files should be added to selection but should NOT change the diff scope; they’re for the reviewer to read alongside the diffs.
 
-## 4) Build RepoPrompt selection (must be resolvable)
+## 4) Build RepoPrompt CE selection (must be resolvable)
 - `selected_paths` = unique(review files ∪ context files), but include only paths that exist in the working tree.
 - If a referenced path doesn’t exist, mention it in the message and continue (do not block).
 
 Selection (CLI):
 ```bash
-rp-cli -e 'select set <selected_paths...>'
+rpce-cli -e 'select set <selected_paths...>'
 ```
 
 ## 5) Send the review chat (no diff pasted)
 ```bash
-rp-cli -e 'review "Review the diffs for the selected files, and if there is a selected file that does not have diffs, use it as context for interpreting the diffs.
+rpce-cli -e 'review "Review the diffs for the selected files, and if there is a selected file that does not have diffs, use it as context for interpreting the diffs.
 
 Additional user notes (if any): <additional notes provided by user, if provided in $ARGUMENTS>"'
 ```

--- a/skills/repoprompt-tool-guidance-refresh/scripts/track-rp-version.sh
+++ b/skills/repoprompt-tool-guidance-refresh/scripts/track-rp-version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tracks rp-cli changes across versions
+# Tracks rpce-cli changes across versions
 # Usage: ./track-rp-version.sh [--pre | --post | --check | --force]
 
 set -euo pipefail
@@ -9,24 +9,24 @@ SCRIPT_DIR="$(dirname "$0")"
 OUTPUT_DIR="${SCRIPT_DIR}/../rp-tool-defs"
 mkdir -p "$OUTPUT_DIR"
 
-# Parse version from `rp-cli -v` output like "rp-cli (repoprompt-mcp) 1.6.0"
+# Parse version from `rpce-cli -v` output like "rpce-cli (repoprompt-mcp) 1.6.0"
 get_version() {
-    rp-cli -v 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
+    rpce-cli -v 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
 }
 
 CURRENT_VERSION=$(get_version)
 BASELINE_FILE="${OUTPUT_DIR}/.baseline_version"
 
 if [ -z "$CURRENT_VERSION" ]; then
-    echo "ERROR: Could not detect rp-cli version. Is rp-cli installed?" >&2
+    echo "ERROR: Could not detect rpce-cli version. Is rpce-cli installed?" >&2
     exit 1
 fi
 
 snapshot() {
     local v="$1"
     echo "Capturing snapshot for v${v}..."
-    rp-cli --help > "${OUTPUT_DIR}/rpcli-help__${v}.txt"
-    rp-cli -l > "${OUTPUT_DIR}/rpcli-l__${v}.txt"
+    rpce-cli --help > "${OUTPUT_DIR}/rpcli-help__${v}.txt"
+    rpce-cli -l > "${OUTPUT_DIR}/rpcli-l__${v}.txt"
     echo "$v" > "$BASELINE_FILE"
 }
 
@@ -91,7 +91,7 @@ case "${1:---check}" in
             if [ "$baseline" = "$CURRENT_VERSION" ]; then
                 echo "✓ Baseline already captured at v${CURRENT_VERSION}"
                 echo ""
-                echo "Ready to upgrade. After updating RepoPrompt, run:"
+                echo "Ready to upgrade. After updating RepoPrompt CE, run:"
                 echo "  ./track-rp-version.sh --post"
                 exit 0
             else
@@ -103,7 +103,7 @@ case "${1:---check}" in
         echo ""
         echo "✓ Baseline captured at v${CURRENT_VERSION}"
         echo ""
-        echo "Ready to upgrade. After updating RepoPrompt, run:"
+        echo "Ready to upgrade. After updating RepoPrompt CE, run:"
         echo "  ./track-rp-version.sh --post"
         ;;
 
@@ -117,7 +117,7 @@ case "${1:---check}" in
 
         baseline=$(cat "$BASELINE_FILE")
         if [ "$baseline" = "$CURRENT_VERSION" ]; then
-            echo "Version unchanged ($CURRENT_VERSION). Did you upgrade RepoPrompt?"
+            echo "Version unchanged ($CURRENT_VERSION). Did you upgrade RepoPrompt CE?"
             exit 1
         fi
 
@@ -147,15 +147,15 @@ case "${1:---check}" in
         echo "Usage: $0 [--pre | --post | --check | --force | --version]"
         echo ""
         echo "Commands:"
-        echo "  --pre, -p     Capture baseline before upgrading RepoPrompt"
+        echo "  --pre, -p     Capture baseline before upgrading RepoPrompt CE"
         echo "  --post, -o    Capture new version after upgrade, generate diffs"
         echo "  --check, -c   Show current vs baseline version (default)"
         echo "  --force, -f   Force re-capture current version (no diff)"
-        echo "  --version, -v Print current rp-cli version"
+        echo "  --version, -v Print current rpce-cli version"
         echo ""
         echo "Workflow:"
         echo "  1. ./track-rp-version.sh --pre    # Before upgrading"
-        echo "  2. (Update RepoPrompt)"
+        echo "  2. (Update RepoPrompt CE)"
         echo "  3. ./track-rp-version.sh --post   # After upgrading"
         ;;
 esac


### PR DESCRIPTION
Updates references to RepoPrompt CE (rpce) tooling across skills, extensions, prefaces, and documentation.