### PR TITLE
fix(command-center): respect skill command setting

### DIFF
--- a/extensions/command-center/README.md
+++ b/extensions/command-center/README.md
@@ -18,6 +18,12 @@ A scrollable overview of available /commands (from extensions, prompts, skills, 
 2. Edit `config.json` to your preferences
 3. Run `/reload`
 
+### Pi skill commands
+
+Command Center follows Pi's `enableSkillCommands` setting. When **Skill commands** is disabled in `/settings` (or `enableSkillCommands` is `false` in `settings.json`), the `SKILLS` section is omitted.
+
+If you change this setting while Command Center is open, close and reopen the widget to refresh it.
+
 ### Recommended defaults
 
 #### Hide built-ins (†)

--- a/extensions/command-center/index.ts
+++ b/extensions/command-center/index.ts
@@ -6,7 +6,13 @@
  * Keybindings are configured in ./config.json (relative to this file).
  */
 
-import type { ExtensionAPI, ExtensionContext, SlashCommandInfo } from "@earendil-works/pi-coding-agent";
+import {
+    getAgentDir,
+    SettingsManager,
+    type ExtensionAPI,
+    type ExtensionContext,
+    type SlashCommandInfo,
+} from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
 import * as fs from "node:fs";
@@ -71,7 +77,13 @@ type ExtensionConfig = {
     display?: ExtensionDisplayConfig;
 };
 
-const DEFAULT_CONFIG: Required<ExtensionConfig> = {
+type ResolvedExtensionConfig = {
+    keybindings: Required<ExtensionKeybindingsConfig>;
+    layout: Required<ExtensionLayoutConfig>;
+    display: Required<ExtensionDisplayConfig>;
+};
+
+const DEFAULT_CONFIG: ResolvedExtensionConfig = {
     keybindings: {
         toggle: "ctrl+/",
         scrollUp: "shift+up",
@@ -87,7 +99,7 @@ const DEFAULT_CONFIG: Required<ExtensionConfig> = {
     },
 };
 
-function loadConfig(): Required<ExtensionConfig> {
+function loadConfig(): ResolvedExtensionConfig {
     const dir = path.dirname(fileURLToPath(import.meta.url));
     const configPath = path.join(dir, "config.json");
 
@@ -163,7 +175,11 @@ function sortCommandStrings(values: string[]): string[] {
     return [...values].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
 }
 
-function buildAllLines(width: number, commands: SlashCommandInfo[], options: { includeBuiltins: boolean }): string[] {
+function buildAllLines(
+    width: number,
+    commands: SlashCommandInfo[],
+    options: { includeBuiltins: boolean; includeSkills: boolean },
+): string[] {
     const lines: string[] = [];
     const g = (s: string) => `\x1b[32m${s}\x1b[0m`; // green
     const c = (s: string) => `\x1b[36m${s}\x1b[0m`; // cyan
@@ -209,14 +225,16 @@ function buildAllLines(width: number, commands: SlashCommandInfo[], options: { i
     }
     lines.push("");
 
-    lines.push(y(b(`SKILLS (${skills.length})`)));
-    if (skills.length > 0) {
-        const maxItemLen = Math.max(...skills.map((s) => s.length));
-        const colWidth = clamp(maxItemLen + 2, 18, 40);
-        const cols = Math.max(1, Math.floor(usableWidth / colWidth));
-        const items = skills.map((s) => c(truncatePlain(s, colWidth - 1)));
-        for (const line of makeColumns(items, colWidth, cols)) {
-            lines.push("  " + line);
+    if (options.includeSkills) {
+        lines.push(y(b(`SKILLS (${skills.length})`)));
+        if (skills.length > 0) {
+            const maxItemLen = Math.max(...skills.map((s) => s.length));
+            const colWidth = clamp(maxItemLen + 2, 18, 40);
+            const cols = Math.max(1, Math.floor(usableWidth / colWidth));
+            const items = skills.map((s) => c(truncatePlain(s, colWidth - 1)));
+            for (const line of makeColumns(items, colWidth, cols)) {
+                lines.push("  " + line);
+            }
         }
     }
     if (options.includeBuiltins) {
@@ -267,17 +285,25 @@ class CommandCenterWidget {
     private tui: WidgetTui;
     private theme: WidgetTheme;
     private pi: ExtensionAPI;
-    private config: Required<ExtensionConfig>;
+    private config: ResolvedExtensionConfig;
+    private skillCommandsEnabled: boolean;
 
     private scroll: number = 0;
     private cachedWidth: number = 0;
     private cachedLines: string[] = [];
 
-    constructor(tui: WidgetTui, theme: WidgetTheme, pi: ExtensionAPI, config: Required<ExtensionConfig>) {
+    constructor(
+        tui: WidgetTui,
+        theme: WidgetTheme,
+        pi: ExtensionAPI,
+        config: ResolvedExtensionConfig,
+        skillCommandsEnabled: boolean,
+    ) {
         this.tui = tui;
         this.theme = theme;
         this.pi = pi;
         this.config = config;
+        this.skillCommandsEnabled = skillCommandsEnabled;
     }
 
     updateTheme(theme: WidgetTheme): void {
@@ -285,8 +311,14 @@ class CommandCenterWidget {
         this.invalidate();
     }
 
-    updateConfig(config: Required<ExtensionConfig>): void {
+    updateConfig(config: ResolvedExtensionConfig): void {
         this.config = config;
+        this.invalidate();
+    }
+
+    updateSkillCommandsEnabled(enabled: boolean): void {
+        if (enabled === this.skillCommandsEnabled) return;
+        this.skillCommandsEnabled = enabled;
         this.invalidate();
     }
 
@@ -313,8 +345,12 @@ class CommandCenterWidget {
         const innerHeight = Math.max(3, height - 4);
 
         if (width !== this.cachedWidth) {
-            this.cachedLines = buildAllLines(width, this.pi.getCommands(), {
+            const commands = this.pi
+                .getCommands()
+                .filter((command) => command.source !== "skill" || this.skillCommandsEnabled);
+            this.cachedLines = buildAllLines(width, commands, {
                 includeBuiltins: this.config.display.includeBuiltins,
+                includeSkills: this.skillCommandsEnabled,
             });
             this.cachedWidth = width;
         }
@@ -388,6 +424,9 @@ export default function commandCenterExtension(pi: ExtensionAPI): void {
 
     const show = (ctx: ExtensionContext) => {
         const config = readConfigAndUpdateWidget();
+        const skillCommandsEnabled = SettingsManager.create(ctx.cwd, getAgentDir(), {
+            projectTrusted: ctx.isProjectTrusted(),
+        }).getEnableSkillCommands();
 
         ctx.ui.setWidget(
             WIDGET_ID,
@@ -398,11 +437,12 @@ export default function commandCenterExtension(pi: ExtensionAPI): void {
                         theme as unknown as WidgetTheme,
                         pi,
                         config,
-                        () => hide(ctx),
+                        skillCommandsEnabled,
                     );
                 } else {
                     widget.updateTheme(theme as unknown as WidgetTheme);
                     widget.updateConfig(config);
+                    widget.updateSkillCommandsEnabled(skillCommandsEnabled);
                 }
                 return widget as any;
             },

--- a/packages/pi-command-center/package.json
+++ b/packages/pi-command-center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-command-center",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Scrollable widget displaying available /commands from extensions/prompts/skills, compatible with simultaneous editor use.",
   "keywords": [
     "pi-package",
@@ -26,7 +26,7 @@
     "image": "https://raw.githubusercontent.com/w-winter/dot314/main/assets/command-center-demo.gif"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.84.0",
     "@earendil-works/pi-tui": "*"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- read Pi's effective `enableSkillCommands` value through `SettingsManager`
- respect project trust when resolving project-level settings
- omit the `SKILLS` section and skill entries when skill commands are disabled
- document that reopening the widget refreshes the setting

## Verification

- `pi_verify` runtime startup passed with `/command-center` registered
- isolated Pi startup passed with no extension errors
- targeted typechecking reaches only the existing `import.meta`/CommonJS diagnostic at `extensions/command-center/index.ts:103` (`TS1470`); no new type errors remain