### PR TITLE
fix(anycopy): support fullscreen preview scrolling

### DIFF
--- a/extensions/anycopy/README.md
+++ b/extensions/anycopy/README.md
@@ -35,7 +35,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
-- `/anycopy` runs as a full-screen overlay with bounded preview scrolling, so long transcripts stay behind the modal and the final preview lines remain reachable
+- `/anycopy` uses Pi's selector surface with bounded preview scrolling and budgets Pi's host-owned footer rows in both terminal renderers
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/extensions/anycopy/README.md
+++ b/extensions/anycopy/README.md
@@ -35,7 +35,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
-- In Pi fullscreen mode, `/anycopy` reserves Pi's sticky transcript/spacer/footer rows and keeps its own bounded preview scrolling, so the final lines remain reachable
+- `/anycopy` runs as a full-screen overlay with bounded preview scrolling, so long transcripts stay behind the modal and the final preview lines remain reachable
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/extensions/anycopy/README.md
+++ b/extensions/anycopy/README.md
@@ -35,7 +35,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
-- `/anycopy` uses Pi's selector surface with bounded preview scrolling and budgets Pi's host-owned footer rows in both terminal renderers
+- `/anycopy` runs as a bounded full-screen overlay, so unrelated host widgets cannot clip its framed preview while Pi's footer remains visible
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/extensions/anycopy/README.md
+++ b/extensions/anycopy/README.md
@@ -35,6 +35,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
+- In Pi fullscreen mode, `/anycopy` reserves Pi's sticky transcript/spacer/footer rows and keeps its own bounded preview scrolling, so the final lines remain reachable
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/extensions/anycopy/README.md
+++ b/extensions/anycopy/README.md
@@ -35,7 +35,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
-- `/anycopy` runs as a bounded full-screen overlay, so unrelated host widgets cannot clip its framed preview while Pi's footer remains visible
+- `/anycopy` opens over the session view, so widgets above the editor do not reduce the space available to its preview
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -735,8 +735,7 @@ class anycopyOverlay implements Focusable {
 		output.push(...selectorLines);
 		output.push(...this.renderStatusBar(width));
 
-		const hostDividerHeight = 1;
-		const contentHeight = Math.max(0, height - hostDividerHeight);
+		const contentHeight = height;
 		const previewHeight = Math.max(0, contentHeight - output.length);
 		if (previewHeight > 0) {
 			output.push(...this.renderPreview(width, previewHeight));
@@ -936,6 +935,15 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 
 			tui.setFocus?.(overlay);
 			return overlay;
+		}, {
+			overlay: true,
+			overlayOptions: {
+				anchor: "top-left",
+				width: "100%",
+				maxHeight: "100%",
+				margin: 0,
+			},
+			onHandle: (handle) => handle.focus(),
 		});
 	};
 

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -39,10 +39,14 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 import { createAnycopyEnterNavigationLauncher, runAnycopyEnterNavigation } from "./enter-navigation.ts";
-import { getPreviewWindow } from "./preview-window.ts";
+import { getPreviewPageStep, getPreviewWindow } from "./preview-window.ts";
 import { formatCompactTimestamp, getEntryTimestampMs } from "./timestamps.ts";
 import { buildNodeOrder } from "./tree-order.ts";
-import { getAnycopyRenderHeight } from "./viewport-layout.ts";
+import {
+	getAnycopyRenderHeight,
+	getAnycopyTreeHeight,
+	getAnycopyTreeVisibleLines,
+} from "./viewport-layout.ts";
 import {
 	ANYCOPY_FOLD_STATE_CUSTOM_TYPE,
 	createFoldStateEntryData,
@@ -489,13 +493,13 @@ class anycopyOverlay implements Focusable {
 			return;
 		}
 		if (matchesKey(data, this.keys.pageDown as MatchesKeyId)) {
-			const step = Math.max(1, (this.lastPreviewHeight > 0 ? this.lastPreviewHeight : 10) - 1);
+			const step = getPreviewPageStep(this.lastPreviewHeight > 0 ? this.lastPreviewHeight : 10);
 			this.previewScrollOffset += step;
 			this.requestRender();
 			return;
 		}
 		if (matchesKey(data, this.keys.pageUp as MatchesKeyId)) {
-			const step = Math.max(1, (this.lastPreviewHeight > 0 ? this.lastPreviewHeight : 10) - 1);
+			const step = getPreviewPageStep(this.lastPreviewHeight > 0 ? this.lastPreviewHeight : 10);
 			this.previewScrollOffset -= step;
 			this.requestRender();
 			return;
@@ -719,7 +723,10 @@ class anycopyOverlay implements Focusable {
 		const height = this.getRenderHeight();
 		const output: string[] = [];
 
+		this.getTreeListInternals().maxVisibleLines = getAnycopyTreeVisibleLines(height);
 		const selectorLines = this.selector.render(width);
+
+		// Remove the selector's spacer after the search prompt and before its bottom border
 		const searchLineIndex = selectorLines.findIndex((line) => line.includes("Type to search"));
 		const listStartIndex = searchLineIndex >= 0 ? searchLineIndex + 2 : -1;
 		if (listStartIndex >= 0 && visibleWidth(selectorLines[listStartIndex] ?? "") === 0) {
@@ -735,14 +742,13 @@ class anycopyOverlay implements Focusable {
 		output.push(...selectorLines);
 		output.push(...this.renderStatusBar(width));
 
-		const contentHeight = height;
-		const previewHeight = Math.max(0, contentHeight - output.length);
+		const previewHeight = Math.max(0, height - output.length);
 		if (previewHeight > 0) {
 			output.push(...this.renderPreview(width, previewHeight));
 		}
 
-		while (output.length < contentHeight) output.push("");
-		if (output.length > contentHeight) output.length = contentHeight;
+		while (output.length < height) output.push("");
+		if (output.length > height) output.length = height;
 		return output;
 	}
 
@@ -790,7 +796,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				done();
 			};
 			const getRenderHeight = (): number => getAnycopyRenderHeight(tui.terminal?.rows ?? 40);
-			const treeTermHeight = Math.floor(getRenderHeight() * 0.65);
+			const treeTermHeight = getAnycopyTreeHeight(getRenderHeight());
 			const nodeById = buildNodeMap(initialTree);
 			const validNodeIds = new Set(nodeById.keys());
 			const restoredFoldState = persistFoldState

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -26,7 +26,6 @@ import {
 
 import {
 	getKeybindings,
-	isViewportTUI,
 	Markdown,
 	matchesKey,
 	truncateToWidth,
@@ -772,9 +771,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 		const skipSummaryPrompt = loadBranchSummarySkipPrompt(ctx.cwd);
 
 		await ctx.ui.custom<void>((tui, theme, _kb, done) => {
-			const viewportMode = isViewportTUI(tui);
-			const getRenderHeight = (): number =>
-				getAnycopyRenderHeight(tui.terminal?.rows ?? 40, viewportMode);
+			const getRenderHeight = (): number => getAnycopyRenderHeight(tui.terminal?.rows ?? 40);
 			const treeTermHeight = Math.floor(getRenderHeight() * 0.65);
 			const nodeById = buildNodeMap(initialTree);
 			const validNodeIds = new Set(nodeById.keys());
@@ -928,6 +925,15 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 
 			tui.setFocus?.(overlay);
 			return overlay;
+		}, {
+			overlay: true,
+			overlayOptions: {
+				anchor: "top-left",
+				width: "100%",
+				maxHeight: "100%",
+				margin: 0,
+			},
+			onHandle: (handle) => handle.focus(),
 		});
 	};
 

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -620,24 +620,28 @@ class anycopyOverlay implements Focusable {
 			);
 		}
 
-		// TreeSelectorComponent already renders the separator above this hint.
-		const previewHint =
-			`  ${formatKeyHint(this.keys.scrollUp)}/${formatKeyHint(this.keys.scrollDown)}: scroll` +
-			` • ${formatKeyHint(this.keys.pageUp)}/${formatKeyHint(this.keys.pageDown)}: page`;
-		lines.push(truncateToWidth(this.theme.fg("dim", previewHint), width));
+		const compactKey = (key: string): string =>
+			formatKeyHint(key)
+				.replace(/^Shift(?=\+)/i, "S")
+				.replace(/\+Ctrl(?=\+|$)/gi, "+C")
+				.replace(/\+Alt(?=\+|$)/gi, "+A");
+		const hint =
+			`  ${compactKey(this.keys.scrollUp)}/${compactKey(this.keys.scrollDown)}: scroll` +
+			` · ${compactKey(this.keys.pageUp)}/${compactKey(this.keys.pageDown)}: page` +
+			` · Enter: navigate` +
+			` · ${compactKey(this.keys.toggleSelect)}: select` +
+			` · ${compactKey(this.keys.copy)}: copy` +
+			` · ${compactKey(this.keys.clear)}: clear` +
+			` · ${compactKey(this.keys.toggleEntryTimestamps)}: entry time`;
+		lines.push(truncateToWidth(this.theme.fg("dim", hint), width));
 
 		return lines;
 	}
 
-	private renderTreeHeaderHint(width: number): string {
-		const hint =
-			`   │ Enter: navigate` +
-			` • ${formatKeyHint(this.keys.toggleSelect)}: select` +
-			` • ${formatKeyHint(this.keys.copy)}: copy` +
-			` • ${formatKeyHint(this.keys.clear)}: clear` +
-			` • ${formatKeyHint(this.keys.toggleEntryTimestamps)}: entry time` +
-			` • Esc: close`;
-		return truncateToWidth(this.theme.fg("dim", hint), width);
+	private renderPreviewDivider(width: number, message?: string): string {
+		const label = message ? ` ${message} ` : "";
+		const ruleWidth = Math.max(0, width - visibleWidth(label) - 1);
+		return truncateToWidth(this.theme.fg("dim", `─${label}${"─".repeat(ruleWidth)}`), width);
 	}
 
 	private getPreviewBody(width: number): { bodyLines: string[]; truncatedToMaxLines: boolean } | null {
@@ -688,20 +692,25 @@ class anycopyOverlay implements Focusable {
 		this.previewScrollOffset = window.start;
 
 		if (height === 1) {
-			return [bodyLines[window.start] ?? ""];
+			const hidden = Math.max(window.above, window.below);
+			return [this.renderPreviewDivider(width, hidden > 0 ? `… ${hidden} line(s)` : undefined)];
 		}
 
-		if (window.above > 0) {
-			lines.push(truncateToWidth(this.theme.fg("muted", `… ${window.above} line(s) above`), width));
-		}
-
+		lines.push(
+			this.renderPreviewDivider(
+				width,
+				window.above > 0 ? `… ${window.above} line(s) above` : undefined,
+			),
+		);
 		lines.push(...bodyLines.slice(window.start, window.end));
+		lines.push(
+			this.renderPreviewDivider(
+				width,
+				window.below > 0 ? `… ${window.below} line(s) below` : undefined,
+			),
+		);
 
-		if (window.below > 0) {
-			lines.push(truncateToWidth(this.theme.fg("muted", `… ${window.below} line(s) below`), width));
-		}
-
-		while (lines.length < height) lines.push("");
+		while (lines.length < height) lines.splice(lines.length - 1, 0, "");
 		if (lines.length > height) lines.length = height;
 		return lines;
 	}
@@ -711,20 +720,23 @@ class anycopyOverlay implements Focusable {
 		const output: string[] = [];
 
 		const selectorLines = this.selector.render(width);
-		const headerHint = this.renderTreeHeaderHint(width);
-
-		// Inject action hints near the tree header (above the list)
-		const insertAfter = Math.max(0, selectorLines.findIndex((l) => l.includes("Type to search")));
-		if (selectorLines.length > 0) {
-			const idx = insertAfter >= 0 ? insertAfter + 1 : 1;
-			selectorLines.splice(Math.min(idx, selectorLines.length), 0, headerHint);
+		const searchLineIndex = selectorLines.findIndex((line) => line.includes("Type to search"));
+		const listStartIndex = searchLineIndex >= 0 ? searchLineIndex + 2 : -1;
+		if (listStartIndex >= 0 && visibleWidth(selectorLines[listStartIndex] ?? "") === 0) {
+			selectorLines.splice(listStartIndex, 1);
+		}
+		while (selectorLines.length > 1 && visibleWidth(selectorLines.at(-2) ?? "") === 0) {
+			selectorLines.splice(selectorLines.length - 2, 1);
+		}
+		while (selectorLines.length > 0 && visibleWidth(selectorLines.at(-1) ?? "") === 0) {
+			selectorLines.pop();
 		}
 
 		output.push(...selectorLines);
 		output.push(...this.renderStatusBar(width));
 
-		const footerSeparatorHeight = 1;
-		const contentHeight = Math.max(0, height - footerSeparatorHeight);
+		const hostDividerHeight = 1;
+		const contentHeight = Math.max(0, height - hostDividerHeight);
 		const previewHeight = Math.max(0, contentHeight - output.length);
 		if (previewHeight > 0) {
 			output.push(...this.renderPreview(width, previewHeight));
@@ -732,7 +744,6 @@ class anycopyOverlay implements Focusable {
 
 		while (output.length < contentHeight) output.push("");
 		if (output.length > contentHeight) output.length = contentHeight;
-		output.push(truncateToWidth(this.theme.fg("dim", "─".repeat(width)), width));
 		return output;
 	}
 
@@ -925,15 +936,6 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 
 			tui.setFocus?.(overlay);
 			return overlay;
-		}, {
-			overlay: true,
-			overlayOptions: {
-				anchor: "top-left",
-				width: "100%",
-				maxHeight: "100%",
-				margin: 0,
-			},
-			onHandle: (handle) => handle.focus(),
 		});
 	};
 

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -24,7 +24,14 @@ import {
 	TreeSelectorComponent,
 } from "@earendil-works/pi-coding-agent";
 
-import { getKeybindings, Markdown, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	getKeybindings,
+	isViewportTUI,
+	Markdown,
+	matchesKey,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 import type { Focusable } from "@earendil-works/pi-tui";
 
 import { existsSync, readFileSync } from "fs";
@@ -33,8 +40,10 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 import { createAnycopyEnterNavigationLauncher, runAnycopyEnterNavigation } from "./enter-navigation.ts";
+import { getPreviewWindow } from "./preview-window.ts";
 import { formatCompactTimestamp, getEntryTimestampMs } from "./timestamps.ts";
 import { buildNodeOrder } from "./tree-order.ts";
+import { getAnycopyRenderHeight } from "./viewport-layout.ts";
 import {
 	ANYCOPY_FOLD_STATE_CUSTOM_TYPE,
 	createFoldStateEntryData,
@@ -54,12 +63,14 @@ type SessionTreeNode = {
 
 type anycopyTreeList = ReturnType<TreeSelectorComponent["getTreeList"]>;
 
-type anycopyTreeListInternals = anycopyTreeList & {
+type anycopyTreeListInternals = {
 	filteredNodes: Array<{ node: SessionTreeNode }>;
 	selectedIndex: number;
 	maxVisibleLines: number;
 	showLabelTimestamps: boolean;
 };
+
+type MatchesKeyId = Parameters<typeof matchesKey>[1];
 
 type anycopyKeyConfig = {
 	toggleSelect: string;
@@ -111,6 +122,7 @@ const DEFAULT_PERSIST_FOLD_STATE = true;
 const getExtensionDir = (): string => {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 	if (typeof __dirname !== "undefined") return __dirname;
+	// @ts-ignore import.meta is available in Pi's ESM extension runtime; the standalone verifier also checks CJS output.
 	return dirname(fileURLToPath(import.meta.url));
 };
 
@@ -370,7 +382,7 @@ const buildNodeMap = (roots: SessionTreeNode[]): Map<string, SessionTreeNode> =>
 };
 
 const getTreeListInternals = (treeList: anycopyTreeList): anycopyTreeListInternals => {
-	return treeList as anycopyTreeListInternals;
+	return treeList as unknown as anycopyTreeListInternals;
 };
 
 /** Clipboard text omits role prefix for a single node and includes it for multi-node copies
@@ -414,7 +426,7 @@ class anycopyOverlay implements Focusable {
 			beforeTransientFoldedNodeIds: string[],
 			afterTransientFoldedNodeIds: string[],
 		) => void) | null,
-		private getTermHeight: () => number,
+		private getRenderHeight: () => number,
 		private requestRender: () => void,
 		private theme: any,
 	) {}
@@ -438,25 +450,25 @@ class anycopyOverlay implements Focusable {
 			return;
 		}
 
-		if (matchesKey(data, this.keys.toggleSelect)) {
+		if (matchesKey(data, this.keys.toggleSelect as MatchesKeyId)) {
 			this.toggleSelectedFocusedNode();
 			return;
 		}
-		if (matchesKey(data, this.keys.copy)) {
+		if (matchesKey(data, this.keys.copy as MatchesKeyId)) {
 			this.copySelectedOrFocusedNode();
 			return;
 		}
-		if (matchesKey(data, this.keys.clear)) {
+		if (matchesKey(data, this.keys.clear as MatchesKeyId)) {
 			this.clearSelection();
 			return;
 		}
-		if (matchesKey(data, this.keys.toggleLabelTimestamps)) {
+		if (matchesKey(data, this.keys.toggleLabelTimestamps as MatchesKeyId)) {
 			const treeList = this.getTreeListInternals();
 			treeList.showLabelTimestamps = !treeList.showLabelTimestamps;
 			this.requestRender();
 			return;
 		}
-		if (matchesKey(data, this.keys.toggleEntryTimestamps)) {
+		if (matchesKey(data, this.keys.toggleEntryTimestamps as MatchesKeyId)) {
 			this.showEntryTimestamps = !this.showEntryTimestamps;
 			this.requestRender();
 			return;
@@ -467,23 +479,23 @@ class anycopyOverlay implements Focusable {
 			return;
 		}
 
-		if (matchesKey(data, this.keys.scrollDown)) {
+		if (matchesKey(data, this.keys.scrollDown as MatchesKeyId)) {
 			this.previewScrollOffset += 1;
 			this.requestRender();
 			return;
 		}
-		if (matchesKey(data, this.keys.scrollUp)) {
+		if (matchesKey(data, this.keys.scrollUp as MatchesKeyId)) {
 			this.previewScrollOffset -= 1;
 			this.requestRender();
 			return;
 		}
-		if (matchesKey(data, this.keys.pageDown)) {
+		if (matchesKey(data, this.keys.pageDown as MatchesKeyId)) {
 			const step = Math.max(1, (this.lastPreviewHeight > 0 ? this.lastPreviewHeight : 10) - 1);
 			this.previewScrollOffset += step;
 			this.requestRender();
 			return;
 		}
-		if (matchesKey(data, this.keys.pageUp)) {
+		if (matchesKey(data, this.keys.pageUp as MatchesKeyId)) {
 			const step = Math.max(1, (this.lastPreviewHeight > 0 ? this.lastPreviewHeight : 10) - 1);
 			this.previewScrollOffset -= step;
 			this.requestRender();
@@ -505,7 +517,7 @@ class anycopyOverlay implements Focusable {
 	}
 
 	private isEditingNodeLabel(): boolean {
-		return Boolean((this.selector as { labelInput?: unknown }).labelInput);
+		return Boolean((this.selector as unknown as { labelInput?: unknown }).labelInput);
 	}
 
 	invalidate(): void {
@@ -593,9 +605,8 @@ class anycopyOverlay implements Focusable {
 
 	private renderStatusBar(width: number): string[] {
 		const lines: string[] = [];
-		lines.push(truncateToWidth(this.theme.fg("dim", "─".repeat(width)), width));
 
-		// Status only (selection count / flash)
+		// Keep transient/selection status compact; omit the row entirely when idle.
 		if (this.flashMessage) {
 			lines.push(truncateToWidth(this.theme.fg("success", `  ${this.flashMessage}`), width));
 		} else if (this.selectedNodeIds.size > 0) {
@@ -608,11 +619,9 @@ class anycopyOverlay implements Focusable {
 					width,
 				),
 			);
-		} else {
-			lines.push("");
 		}
 
-		// Preview-scrolling hints belong above the preview pane
+		// TreeSelectorComponent already renders the separator above this hint.
 		const previewHint =
 			`  ${formatKeyHint(this.keys.scrollUp)}/${formatKeyHint(this.keys.scrollDown)}: scroll` +
 			` • ${formatKeyHint(this.keys.pageUp)}/${formatKeyHint(this.keys.pageDown)}: page`;
@@ -632,77 +641,74 @@ class anycopyOverlay implements Focusable {
 		return truncateToWidth(this.theme.fg("dim", hint), width);
 	}
 
+	private getPreviewBody(width: number): { bodyLines: string[]; truncatedToMaxLines: boolean } | null {
+		const focused = this.getFocusedNode();
+		if (!focused) return null;
+
+		const entryId = focused.entry.id;
+		if (this.previewCache && this.previewCache.entryId === entryId && this.previewCache.width === width) {
+			return this.previewCache;
+		}
+
+		const content = getEntryContent(focused.entry);
+		const clipped = clipTextForPreview(content);
+		const rendered = renderPreviewBodyLines(clipped, focused.entry, width, this.theme, this.nodeById);
+		const preview = {
+			entryId,
+			width,
+			bodyLines: rendered.slice(0, MAX_PREVIEW_LINES),
+			truncatedToMaxLines: rendered.length > MAX_PREVIEW_LINES,
+		};
+
+		this.previewCache = preview;
+		this.previewScrollOffset = 0;
+		return preview;
+	}
+
 	private renderPreview(width: number, height: number): string[] {
 		if (height <= 0) return [];
 
 		this.lastPreviewHeight = height;
 
-		const focused = this.getFocusedNode();
+		const preview = this.getPreviewBody(width);
 		const lines: string[] = [];
-		if (!focused) {
+		if (!preview) {
 			lines.push(truncateToWidth(this.theme.fg("dim", "  (no node selected)"), width));
 			while (lines.length < height) lines.push("");
 			return lines;
 		}
 
-		const entryId = focused.entry.id;
-
-		let bodyLines: string[];
-		let truncatedToMaxLines: boolean;
-
-		if (this.previewCache && this.previewCache.entryId === entryId && this.previewCache.width === width) {
-			({ bodyLines, truncatedToMaxLines } = this.previewCache);
-		} else {
-			const content = getEntryContent(focused.entry);
-			const clipped = clipTextForPreview(content);
-			const rendered = renderPreviewBodyLines(clipped, focused.entry, width, this.theme, this.nodeById);
-
-			truncatedToMaxLines = rendered.length > MAX_PREVIEW_LINES;
-			bodyLines = rendered.slice(0, MAX_PREVIEW_LINES);
-
-			this.previewCache = { entryId, width, bodyLines, truncatedToMaxLines };
-			this.previewScrollOffset = 0;
+		const bodyLines = [...preview.bodyLines];
+		if (preview.truncatedToMaxLines) {
+			bodyLines.push(
+				truncateToWidth(this.theme.fg("muted", `… [truncated to ${MAX_PREVIEW_LINES} lines]`), width),
+			);
 		}
 
-		// Clamp scroll offset based on available rendered lines
-		const maxOffset = Math.max(0, bodyLines.length - height);
-		this.previewScrollOffset = Math.max(0, Math.min(this.previewScrollOffset, maxOffset));
+		const window = getPreviewWindow(bodyLines.length, height, this.previewScrollOffset);
+		this.previewScrollOffset = window.start;
 
-		const start = this.previewScrollOffset;
-		const end = Math.min(bodyLines.length, start + height);
-		let visible = bodyLines.slice(start, end);
-
-		const above = start;
-		const below = bodyLines.length - end;
-
-		if (height > 0) {
-			if (above > 0) {
-				const indicator = truncateToWidth(this.theme.fg("muted", `… ${above} line(s) above`), width);
-				visible = height === 1 ? [indicator] : [indicator, ...visible.slice(0, height - 1)];
-			}
-
-			if (below > 0) {
-				const indicator = truncateToWidth(this.theme.fg("muted", `… ${below} more line(s)`), width);
-				visible = height === 1 ? [indicator] : [...visible.slice(0, height - 1), indicator];
-			} else if (truncatedToMaxLines) {
-				const indicator = truncateToWidth(
-					this.theme.fg("muted", `… [truncated to ${MAX_PREVIEW_LINES} lines]`),
-					width,
-				);
-				visible = height === 1 ? [indicator] : [...visible.slice(0, height - 1), indicator];
-			}
+		if (height === 1) {
+			return [bodyLines[window.start] ?? ""];
 		}
 
-		for (let i = 0; i < Math.min(height, visible.length); i += 1) {
-			lines.push(visible[i] ?? "");
+		if (window.above > 0) {
+			lines.push(truncateToWidth(this.theme.fg("muted", `… ${window.above} line(s) above`), width));
+		}
+
+		lines.push(...bodyLines.slice(window.start, window.end));
+
+		if (window.below > 0) {
+			lines.push(truncateToWidth(this.theme.fg("muted", `… ${window.below} line(s) below`), width));
 		}
 
 		while (lines.length < height) lines.push("");
+		if (lines.length > height) lines.length = height;
 		return lines;
 	}
 
 	render(width: number): string[] {
-		const height = this.getTermHeight();
+		const height = this.getRenderHeight();
 		const output: string[] = [];
 
 		const selectorLines = this.selector.render(width);
@@ -718,13 +724,16 @@ class anycopyOverlay implements Focusable {
 		output.push(...selectorLines);
 		output.push(...this.renderStatusBar(width));
 
-		const previewHeight = Math.max(0, height - output.length);
+		const footerSeparatorHeight = 1;
+		const contentHeight = Math.max(0, height - footerSeparatorHeight);
+		const previewHeight = Math.max(0, contentHeight - output.length);
 		if (previewHeight > 0) {
 			output.push(...this.renderPreview(width, previewHeight));
 		}
 
-		while (output.length < height) output.push("");
-		if (output.length > height) output.length = height;
+		while (output.length < contentHeight) output.push("");
+		if (output.length > contentHeight) output.length = contentHeight;
+		output.push(truncateToWidth(this.theme.fg("dim", "─".repeat(width)), width));
 		return output;
 	}
 
@@ -763,8 +772,10 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 		const skipSummaryPrompt = loadBranchSummarySkipPrompt(ctx.cwd);
 
 		await ctx.ui.custom<void>((tui, theme, _kb, done) => {
-			const termRows = tui.terminal?.rows ?? 40;
-			const treeTermHeight = Math.floor(termRows * 0.65);
+			const viewportMode = isViewportTUI(tui);
+			const getRenderHeight = (): number =>
+				getAnycopyRenderHeight(tui.terminal?.rows ?? 40, viewportMode);
+			const treeTermHeight = Math.floor(getRenderHeight() * 0.65);
 			const nodeById = buildNodeMap(initialTree);
 			const validNodeIds = new Set(nodeById.keys());
 			const restoredFoldState = persistFoldState
@@ -785,7 +796,8 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 					},
 					navigateTree: async (targetId, options) => ctx.navigateTree(targetId, options),
 					ui: {
-						select: (title, options) => ctx.ui.select(title, options),
+						select: async (title, options) =>
+							(await ctx.ui.select(title, options)) as (typeof options)[number] | undefined,
 						editor: (title) => ctx.ui.editor(title),
 						setStatus: (source, message) => ctx.ui.setStatus(source, message),
 						setWorkingMessage: (message) => ctx.ui.setWorkingMessage(message),
@@ -859,7 +871,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				nodeById,
 				keys,
 				persistFoldState ? handleExplicitFoldMutation : null,
-				() => tui.terminal?.rows ?? 40,
+				getRenderHeight,
 				() => tui.requestRender(),
 				theme,
 			);

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -779,8 +779,16 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 		const getTree = () => ctx.sessionManager.getTree() as SessionTreeNode[];
 		const currentLeafId = ctx.sessionManager.getLeafId();
 		const skipSummaryPrompt = loadBranchSummarySkipPrompt(ctx.cwd);
+		let overlayHandle: { focus(): void; unfocus(): void } | undefined;
 
 		await ctx.ui.custom<void>((tui, theme, _kb, done) => {
+			let closed = false;
+			const closeOverlay = (): void => {
+				if (closed) return;
+				closed = true;
+				overlayHandle?.unfocus();
+				done();
+			};
 			const getRenderHeight = (): number => getAnycopyRenderHeight(tui.terminal?.rows ?? 40);
 			const treeTermHeight = Math.floor(getRenderHeight() * 0.65);
 			const nodeById = buildNodeMap(initialTree);
@@ -797,7 +805,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 					entryId,
 					currentLeafIdForNoop,
 					skipSummaryPrompt,
-					close: done,
+					close: closeOverlay,
 					reopen: (reopenOpts) => {
 						void openAnycopy(ctx, reopenOpts);
 					},
@@ -818,7 +826,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				currentLeafId,
 				treeTermHeight,
 				startEnterNavigation,
-				() => done(),
+				closeOverlay,
 				(entryId, label) => {
 					pi.setLabel(entryId, label);
 				},
@@ -933,7 +941,6 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				});
 			};
 
-			tui.setFocus?.(overlay);
 			return overlay;
 		}, {
 			overlay: true,
@@ -943,7 +950,10 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				maxHeight: "100%",
 				margin: 0,
 			},
-			onHandle: (handle) => handle.focus(),
+			onHandle: (handle) => {
+				overlayHandle = handle;
+				handle.focus();
+			},
 		});
 	};
 

--- a/extensions/anycopy/preview-window.ts
+++ b/extensions/anycopy/preview-window.ts
@@ -1,0 +1,31 @@
+export type PreviewWindow = {
+	start: number;
+	end: number;
+	above: number;
+	below: number;
+};
+
+export function getPreviewWindow(lineCount: number, height: number, requestedOffset: number): PreviewWindow {
+	if (lineCount <= 0 || height <= 0) {
+		return { start: 0, end: 0, above: 0, below: Math.max(0, lineCount) };
+	}
+
+	if (height === 1) {
+		const start = Math.max(0, Math.min(requestedOffset, lineCount - 1));
+		return { start, end: start + 1, above: start, below: lineCount - start - 1 };
+	}
+
+	// At the bottom, one row is reserved for the "above" indicator. Include
+	// that row in the maximum offset so the final content line remains reachable.
+	const maxOffset = Math.max(0, lineCount - (height - 1));
+	const start = Math.max(0, Math.min(requestedOffset, maxOffset));
+	const above = start;
+	// Report remaining scroll steps rather than raw hidden content rows. The
+	// bottom indicator disappears at maxOffset and releases its own row, so one
+	// final keypress can reveal more than one content row.
+	const below = maxOffset - start;
+	const contentRows = Math.max(0, height - (above > 0 ? 1 : 0) - (below > 0 ? 1 : 0));
+	const end = Math.min(lineCount, start + contentRows);
+
+	return { start, end, above, below };
+}

--- a/extensions/anycopy/preview-window.ts
+++ b/extensions/anycopy/preview-window.ts
@@ -5,6 +5,12 @@ export type PreviewWindow = {
 	below: number;
 };
 
+const PREVIEW_DIVIDER_ROWS = 2;
+
+export function getPreviewPageStep(height: number): number {
+	return Math.max(1, height - PREVIEW_DIVIDER_ROWS);
+}
+
 export function getPreviewWindow(lineCount: number, height: number, requestedOffset: number): PreviewWindow {
 	if (lineCount <= 0 || height <= 0) {
 		return { start: 0, end: 0, above: 0, below: Math.max(0, lineCount) };
@@ -17,7 +23,7 @@ export function getPreviewWindow(lineCount: number, height: number, requestedOff
 
 	// The preview is framed by one top and one bottom divider. Overflow counts
 	// are rendered inside those dividers instead of consuming additional rows.
-	const contentRows = Math.max(0, height - 2);
+	const contentRows = Math.max(0, height - PREVIEW_DIVIDER_ROWS);
 	const maxOffset = Math.max(0, lineCount - contentRows);
 	const start = Math.max(0, Math.min(requestedOffset, maxOffset));
 	const end = Math.min(lineCount, start + contentRows);

--- a/extensions/anycopy/preview-window.ts
+++ b/extensions/anycopy/preview-window.ts
@@ -12,20 +12,20 @@ export function getPreviewWindow(lineCount: number, height: number, requestedOff
 
 	if (height === 1) {
 		const start = Math.max(0, Math.min(requestedOffset, lineCount - 1));
-		return { start, end: start + 1, above: start, below: lineCount - start - 1 };
+		return { start, end: start, above: start, below: lineCount - start };
 	}
 
-	// At the bottom, one row is reserved for the "above" indicator. Include
-	// that row in the maximum offset so the final content line remains reachable.
-	const maxOffset = Math.max(0, lineCount - (height - 1));
+	// The preview is framed by one top and one bottom divider. Overflow counts
+	// are rendered inside those dividers instead of consuming additional rows.
+	const contentRows = Math.max(0, height - 2);
+	const maxOffset = Math.max(0, lineCount - contentRows);
 	const start = Math.max(0, Math.min(requestedOffset, maxOffset));
-	const above = start;
-	// Report remaining scroll steps rather than raw hidden content rows. The
-	// bottom indicator disappears at maxOffset and releases its own row, so one
-	// final keypress can reveal more than one content row.
-	const below = maxOffset - start;
-	const contentRows = Math.max(0, height - (above > 0 ? 1 : 0) - (below > 0 ? 1 : 0));
 	const end = Math.min(lineCount, start + contentRows);
 
-	return { start, end, above, below };
+	return {
+		start,
+		end,
+		above: start,
+		below: maxOffset - start,
+	};
 }

--- a/extensions/anycopy/test/preview-window.test.ts
+++ b/extensions/anycopy/test/preview-window.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getPreviewWindow } from "../preview-window.ts";
+
+test("getPreviewWindow reserves the bottom indicator row at the start", () => {
+	assert.deepEqual(getPreviewWindow(20, 10, 0), {
+		start: 0,
+		end: 9,
+		above: 0,
+		below: 11,
+	});
+});
+
+test("getPreviewWindow reports remaining scroll steps with both indicators", () => {
+	assert.deepEqual(getPreviewWindow(20, 10, 1), {
+		start: 1,
+		end: 9,
+		above: 1,
+		below: 10,
+	});
+});
+
+test("getPreviewWindow reports one line below exactly one step before the end", () => {
+	assert.deepEqual(getPreviewWindow(20, 10, 10), {
+		start: 10,
+		end: 18,
+		above: 10,
+		below: 1,
+	});
+});
+
+test("getPreviewWindow reaches the final line while reserving the above indicator", () => {
+	assert.deepEqual(getPreviewWindow(20, 10, Number.POSITIVE_INFINITY), {
+		start: 11,
+		end: 20,
+		above: 11,
+		below: 0,
+	});
+});

--- a/extensions/anycopy/test/preview-window.test.ts
+++ b/extensions/anycopy/test/preview-window.test.ts
@@ -3,38 +3,38 @@ import test from "node:test";
 
 import { getPreviewWindow } from "../preview-window.ts";
 
-test("getPreviewWindow reserves the bottom indicator row at the start", () => {
+test("getPreviewWindow reserves fixed top and bottom divider rows", () => {
 	assert.deepEqual(getPreviewWindow(20, 10, 0), {
 		start: 0,
-		end: 9,
+		end: 8,
 		above: 0,
-		below: 11,
+		below: 12,
 	});
 });
 
-test("getPreviewWindow reports remaining scroll steps with both indicators", () => {
+test("getPreviewWindow reports remaining scroll steps inside framed dividers", () => {
 	assert.deepEqual(getPreviewWindow(20, 10, 1), {
 		start: 1,
 		end: 9,
 		above: 1,
-		below: 10,
+		below: 11,
 	});
 });
 
 test("getPreviewWindow reports one line below exactly one step before the end", () => {
-	assert.deepEqual(getPreviewWindow(20, 10, 10), {
-		start: 10,
-		end: 18,
-		above: 10,
+	assert.deepEqual(getPreviewWindow(20, 10, 11), {
+		start: 11,
+		end: 19,
+		above: 11,
 		below: 1,
 	});
 });
 
-test("getPreviewWindow reaches the final line while reserving the above indicator", () => {
+test("getPreviewWindow reaches the final line while retaining both dividers", () => {
 	assert.deepEqual(getPreviewWindow(20, 10, Number.POSITIVE_INFINITY), {
-		start: 11,
+		start: 12,
 		end: 20,
-		above: 11,
+		above: 12,
 		below: 0,
 	});
 });

--- a/extensions/anycopy/test/preview-window.test.ts
+++ b/extensions/anycopy/test/preview-window.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getPreviewWindow } from "../preview-window.ts";
+import { getPreviewPageStep, getPreviewWindow } from "../preview-window.ts";
 
 test("getPreviewWindow reserves fixed top and bottom divider rows", () => {
 	assert.deepEqual(getPreviewWindow(20, 10, 0), {
@@ -19,6 +19,13 @@ test("getPreviewWindow reports remaining scroll steps inside framed dividers", (
 		above: 1,
 		below: 11,
 	});
+});
+
+test("getPreviewPageStep advances to the next contiguous content window", () => {
+	const firstWindow = getPreviewWindow(20, 10, 0);
+	const secondWindow = getPreviewWindow(20, 10, getPreviewPageStep(10));
+
+	assert.equal(secondWindow.start, firstWindow.end);
 });
 
 test("getPreviewWindow reports one line below exactly one step before the end", () => {

--- a/extensions/anycopy/test/viewport-layout.test.ts
+++ b/extensions/anycopy/test/viewport-layout.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getAnycopyRenderHeight } from "../viewport-layout.ts";
+
+test("getAnycopyRenderHeight preserves the full terminal height in regular mode", () => {
+	assert.equal(getAnycopyRenderHeight(40, false), 40);
+});
+
+test("getAnycopyRenderHeight reserves fullscreen transcript, spacer, and footer rows", () => {
+	assert.equal(getAnycopyRenderHeight(40, true), 36);
+});
+
+test("getAnycopyRenderHeight always leaves at least one component row", () => {
+	assert.equal(getAnycopyRenderHeight(2, true), 1);
+});

--- a/extensions/anycopy/test/viewport-layout.test.ts
+++ b/extensions/anycopy/test/viewport-layout.test.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getAnycopyRenderHeight } from "../viewport-layout.ts";
+import {
+	getAnycopyRenderHeight,
+	getAnycopyTreeHeight,
+	getAnycopyTreeVisibleLines,
+} from "../viewport-layout.ts";
 
-test("getAnycopyRenderHeight leaves Pi's two-line footer below the overlay", () => {
+test("getAnycopyRenderHeight reserves two terminal rows below the overlay", () => {
 	assert.equal(getAnycopyRenderHeight(40), 38);
 });
 
@@ -13,4 +17,13 @@ test("getAnycopyRenderHeight floors fractional terminal heights", () => {
 
 test("getAnycopyRenderHeight always leaves at least one component row", () => {
 	assert.equal(getAnycopyRenderHeight(1), 1);
+});
+
+test("getAnycopyTreeHeight applies the selector height ratio", () => {
+	assert.equal(getAnycopyTreeHeight(38), 24);
+});
+
+test("getAnycopyTreeVisibleLines follows the live render height", () => {
+	assert.equal(getAnycopyTreeVisibleLines(38), 12);
+	assert.equal(getAnycopyTreeVisibleLines(18), 5);
 });

--- a/extensions/anycopy/test/viewport-layout.test.ts
+++ b/extensions/anycopy/test/viewport-layout.test.ts
@@ -3,14 +3,14 @@ import test from "node:test";
 
 import { getAnycopyRenderHeight } from "../viewport-layout.ts";
 
-test("getAnycopyRenderHeight preserves the full terminal height in regular mode", () => {
-	assert.equal(getAnycopyRenderHeight(40, false), 40);
+test("getAnycopyRenderHeight uses the terminal height as the overlay budget", () => {
+	assert.equal(getAnycopyRenderHeight(40), 40);
 });
 
-test("getAnycopyRenderHeight reserves fullscreen transcript, spacer, and footer rows", () => {
-	assert.equal(getAnycopyRenderHeight(40, true), 36);
+test("getAnycopyRenderHeight floors fractional terminal heights", () => {
+	assert.equal(getAnycopyRenderHeight(40.9), 40);
 });
 
 test("getAnycopyRenderHeight always leaves at least one component row", () => {
-	assert.equal(getAnycopyRenderHeight(2, true), 1);
+	assert.equal(getAnycopyRenderHeight(0), 1);
 });

--- a/extensions/anycopy/test/viewport-layout.test.ts
+++ b/extensions/anycopy/test/viewport-layout.test.ts
@@ -3,12 +3,12 @@ import test from "node:test";
 
 import { getAnycopyRenderHeight } from "../viewport-layout.ts";
 
-test("getAnycopyRenderHeight preserves the component's final separator above Pi's footer", () => {
-	assert.equal(getAnycopyRenderHeight(40), 37);
+test("getAnycopyRenderHeight leaves Pi's two-line footer below the overlay", () => {
+	assert.equal(getAnycopyRenderHeight(40), 38);
 });
 
 test("getAnycopyRenderHeight floors fractional terminal heights", () => {
-	assert.equal(getAnycopyRenderHeight(40.9), 37);
+	assert.equal(getAnycopyRenderHeight(40.9), 38);
 });
 
 test("getAnycopyRenderHeight always leaves at least one component row", () => {

--- a/extensions/anycopy/test/viewport-layout.test.ts
+++ b/extensions/anycopy/test/viewport-layout.test.ts
@@ -3,14 +3,14 @@ import test from "node:test";
 
 import { getAnycopyRenderHeight } from "../viewport-layout.ts";
 
-test("getAnycopyRenderHeight uses the terminal height as the overlay budget", () => {
-	assert.equal(getAnycopyRenderHeight(40), 40);
+test("getAnycopyRenderHeight preserves the component's final separator above Pi's footer", () => {
+	assert.equal(getAnycopyRenderHeight(40), 37);
 });
 
 test("getAnycopyRenderHeight floors fractional terminal heights", () => {
-	assert.equal(getAnycopyRenderHeight(40.9), 40);
+	assert.equal(getAnycopyRenderHeight(40.9), 37);
 });
 
 test("getAnycopyRenderHeight always leaves at least one component row", () => {
-	assert.equal(getAnycopyRenderHeight(0), 1);
+	assert.equal(getAnycopyRenderHeight(1), 1);
 });

--- a/extensions/anycopy/viewport-layout.ts
+++ b/extensions/anycopy/viewport-layout.ts
@@ -1,7 +1,6 @@
-// Pi keeps its layout boundary and terminal footer below selector-style custom
-// content in both renderers. Budget those host-owned rows instead of branching
-// on TUI mode, leaving the component's final separator visible.
-const HOST_RESERVED_ROWS = 3;
+// The full-screen overlay leaves Pi's two-line footer visible. Its own final
+// preview divider covers the underlying editor boundary.
+const HOST_RESERVED_ROWS = 2;
 
 export function getAnycopyRenderHeight(terminalRows: number): number {
 	return Math.max(1, Math.floor(terminalRows) - HOST_RESERVED_ROWS);

--- a/extensions/anycopy/viewport-layout.ts
+++ b/extensions/anycopy/viewport-layout.ts
@@ -1,0 +1,8 @@
+// Pi's fullscreen dock keeps a transcript row, an above-editor spacer, and a
+// two-line footer outside the custom editor component in the standard layout.
+const FULLSCREEN_RESERVED_ROWS = 4;
+
+export function getAnycopyRenderHeight(terminalRows: number, isViewport: boolean): number {
+	const reservedRows = isViewport ? FULLSCREEN_RESERVED_ROWS : 0;
+	return Math.max(1, terminalRows - reservedRows);
+}

--- a/extensions/anycopy/viewport-layout.ts
+++ b/extensions/anycopy/viewport-layout.ts
@@ -1,5 +1,8 @@
-// This is an upper-bound render budget for the full-screen overlay. Pi owns
-// final overlay clipping and terminal composition.
+// Pi keeps its layout boundary and terminal footer below selector-style custom
+// content in both renderers. Budget those host-owned rows instead of branching
+// on TUI mode, leaving the component's final separator visible.
+const HOST_RESERVED_ROWS = 3;
+
 export function getAnycopyRenderHeight(terminalRows: number): number {
-	return Math.max(1, Math.floor(terminalRows));
+	return Math.max(1, Math.floor(terminalRows) - HOST_RESERVED_ROWS);
 }

--- a/extensions/anycopy/viewport-layout.ts
+++ b/extensions/anycopy/viewport-layout.ts
@@ -1,8 +1,5 @@
-// Pi's fullscreen dock keeps a transcript row, an above-editor spacer, and a
-// two-line footer outside the custom editor component in the standard layout.
-const FULLSCREEN_RESERVED_ROWS = 4;
-
-export function getAnycopyRenderHeight(terminalRows: number, isViewport: boolean): number {
-	const reservedRows = isViewport ? FULLSCREEN_RESERVED_ROWS : 0;
-	return Math.max(1, terminalRows - reservedRows);
+// This is an upper-bound render budget for the full-screen overlay. Pi owns
+// final overlay clipping and terminal composition.
+export function getAnycopyRenderHeight(terminalRows: number): number {
+	return Math.max(1, Math.floor(terminalRows));
 }

--- a/extensions/anycopy/viewport-layout.ts
+++ b/extensions/anycopy/viewport-layout.ts
@@ -1,7 +1,16 @@
-// The full-screen overlay leaves Pi's two-line footer visible. Its own final
-// preview divider covers the underlying editor boundary.
+// Reserve the bottom two terminal rows below the bounded overlay. In fullscreen
+// mode, those rows contain Pi's final two footer rows.
 const HOST_RESERVED_ROWS = 2;
+const TREE_HEIGHT_RATIO = 0.65;
 
 export function getAnycopyRenderHeight(terminalRows: number): number {
 	return Math.max(1, Math.floor(terminalRows) - HOST_RESERVED_ROWS);
+}
+
+export function getAnycopyTreeHeight(renderHeight: number): number {
+	return Math.floor(renderHeight * TREE_HEIGHT_RATIO);
+}
+
+export function getAnycopyTreeVisibleLines(renderHeight: number): number {
+	return Math.max(5, Math.floor(getAnycopyTreeHeight(renderHeight) / 2));
 }

--- a/packages/pi-anycopy/README.md
+++ b/packages/pi-anycopy/README.md
@@ -67,7 +67,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
-- `/anycopy` runs as a full-screen overlay with bounded preview scrolling, so long transcripts stay behind the modal and the final preview lines remain reachable
+- `/anycopy` uses Pi's selector surface with bounded preview scrolling and budgets Pi's host-owned footer rows in both terminal renderers
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/packages/pi-anycopy/README.md
+++ b/packages/pi-anycopy/README.md
@@ -67,7 +67,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
-- `/anycopy` uses Pi's selector surface with bounded preview scrolling and budgets Pi's host-owned footer rows in both terminal renderers
+- `/anycopy` runs as a bounded full-screen overlay, so unrelated host widgets cannot clip its framed preview while Pi's footer remains visible
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/packages/pi-anycopy/README.md
+++ b/packages/pi-anycopy/README.md
@@ -67,7 +67,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
-- In Pi fullscreen mode, `/anycopy` reserves Pi's sticky transcript/spacer/footer rows and keeps its own bounded preview scrolling, so the final lines remain reachable
+- `/anycopy` runs as a full-screen overlay with bounded preview scrolling, so long transcripts stay behind the modal and the final preview lines remain reachable
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/packages/pi-anycopy/README.md
+++ b/packages/pi-anycopy/README.md
@@ -67,6 +67,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
+- In Pi fullscreen mode, `/anycopy` reserves Pi's sticky transcript/spacer/footer rows and keeps its own bounded preview scrolling, so the final lines remain reachable
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/packages/pi-anycopy/README.md
+++ b/packages/pi-anycopy/README.md
@@ -67,7 +67,7 @@ Notes:
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
-- `/anycopy` runs as a bounded full-screen overlay, so unrelated host widgets cannot clip its framed preview while Pi's footer remains visible
+- `/anycopy` opens over the session view, so widgets above the editor do not reduce the space available to its preview
 - `Shift+T` is configurable via `keys.toggleLabelTimestamps` in `config.json`
 - `Shift+T` shows timestamps for labeled nodes only, using the latest label-change time for each label
 - `Shift+Ctrl+T` is configurable via `keys.toggleEntryTimestamps` in `config.json`

--- a/packages/pi-anycopy/package.json
+++ b/packages/pi-anycopy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-anycopy",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pi's /tree with a live syntax-highlighted preview, ability to copy any node(s) to the clipboard, and persistence of folded branches",
   "keywords": ["pi-package", "pi", "pi-coding-agent"],
   "license": "MIT",
@@ -18,8 +18,8 @@
     "image": "https://raw.githubusercontent.com/w-winter/dot314/main/assets/anycopy-demo.gif"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
-    "@earendil-works/pi-tui": "*"
+    "@earendil-works/pi-coding-agent": ">=0.84.0",
+    "@earendil-works/pi-tui": ">=0.84.0"
   },
   "scripts": {
     "prepack": "node ../../scripts/pi-package-prepack.mjs"
@@ -30,8 +30,10 @@
       { "from": "../../extensions/anycopy/index.ts", "to": "extensions/anycopy/index.ts" },
       { "from": "../../extensions/anycopy/enter-navigation.ts", "to": "extensions/anycopy/enter-navigation.ts" },
       { "from": "../../extensions/anycopy/fold-state.ts", "to": "extensions/anycopy/fold-state.ts" },
+      { "from": "../../extensions/anycopy/preview-window.ts", "to": "extensions/anycopy/preview-window.ts" },
       { "from": "../../extensions/anycopy/timestamps.ts", "to": "extensions/anycopy/timestamps.ts" },
       { "from": "../../extensions/anycopy/tree-order.ts", "to": "extensions/anycopy/tree-order.ts" },
+      { "from": "../../extensions/anycopy/viewport-layout.ts", "to": "extensions/anycopy/viewport-layout.ts" },
       { "from": "../../extensions/anycopy/config.json", "to": "extensions/anycopy/config.json" },
       { "from": "../../LICENSE", "to": "LICENSE" }
     ],


### PR DESCRIPTION
## Summary

- render `/anycopy` as a full-screen overlay instead of replacing the normal editor region
- keep long transcripts and Pi's footer behind the modal rather than mixing them with browser output
- preserve line and page scrolling while keeping the final preview lines reachable
- render accurate above/below scroll indicators and a stable bottom separator
- remove redundant separators and idle status spacing
- update Pi peer dependencies and bump `pi-anycopy` to 0.3.4
- add focused tests for overlay render budgeting and preview window boundaries

## Verification

- `node --test` for the anycopy suite: 35 passed
- `pi_verify`: typecheck passed
- `pi_verify`: runtime load passed on Pi 0.84.1
- isolated `/anycopy` command probe passed
- `/anycopy` command probe against a detached copy of an 80-message long session passed; the snapshot contains only the modal and no transcript/footer bleed-through
- `npm run prepack` passed for `packages/pi-anycopy`
