### PR TITLE
feat(anycopy): focus tree and preview interactions

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -95,7 +95,8 @@
 - ● [`anycopy/`](anycopy/) ([README](./anycopy/README.md))
   - `/anycopy` mirrors all behaviors of Pi's native `/tree` while adding a live, syntax-highlighted preview of each node's content, the ability to copy any node(s) to the clipboard, and optional node creation timestamps
   - `Enter` navigates to focused node (same semantics as `/tree`, including the summary chooser and `branchSummary.skipPrompt` support)
-  - `Space` select/unselect for copy, `Shift+C` copy (selected or focused), `Shift+X` clear selection, `Shift+L` label node last updated timestamp, `Shift+Ctrl+T` node creation timestamps
+  - `Shift+A` selects nodes, `Shift+R` extends an inclusive range, and `Shift+C` copies the selection. Tool-result nodes include their originating call
+  - `Tab` toggles tree-focused and preview-focused layouts. `?` shows effective native tree and anycopy bindings
   - `Shift+Up`/`Down` scroll preview by line, `Shift+PageUp`/`PageDown` page preview
   - Single-node copies use just the node's content; role prefixes are only added when copying 2+ nodes
   - Multi-selected nodes are auto-sorted chronologically (by tree position)

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -95,13 +95,13 @@
 - ● [`anycopy/`](anycopy/) ([README](./anycopy/README.md))
   - `/anycopy` mirrors all behaviors of Pi's native `/tree` while adding a live, syntax-highlighted preview of each node's content, the ability to copy any node(s) to the clipboard, and optional node creation timestamps
   - `Enter` navigates to focused node (same semantics as `/tree`, including the summary chooser and `branchSummary.skipPrompt` support)
-  - `Shift+A` selects nodes, `Shift+R` adds an inclusive range, and `Shift+C` copies while retaining the selection. Tool-result nodes include their originating call
-  - An optional copy-only shortcut preserves the editor draft. `Tab` toggles tree-focused and preview-focused layouts. `?` shows effective native tree and anycopy bindings
+  - `Shift+A` selects or deselects individual nodes, `Shift+R` adds an inclusive range, and `Shift+C` copies while retaining the selection. Tool-result previews and clipboard output include the originating call
+  - An optional copy-only shortcut preserves the editor draft. `Tab` toggles tree-focused and preview-focused layouts. `?` shows available native tree and anycopy keybindings
   - `Shift+Up`/`Down` scroll preview by line, `Shift+PageUp`/`PageDown` page preview
   - Single-node copies use just the node's content; role prefixes are only added when copying 2+ nodes
-  - Custom entries use readable labeled preview and clipboard output with local-time timestamp formatting
+  - Custom entries use readable labeled content in previews and clipboard output, with timestamps shown in the local time zone
   - Multi-selected nodes are auto-sorted chronologically (by tree position)
-  - `anycopy/config.json` is the canonical configuration file for the shortcut, hint mode, layout ratios, tree filter, fold persistence, and overlay keys
+  - Configure the shortcut, hint mode, layout ratios, tree filter, fold persistence, and overlay keys in `anycopy/config.json`
 
 <p align="center">
   <img width="450" alt="anycopy demo" src="https://raw.githubusercontent.com/w-winter/dot314/main/assets/anycopy-demo.gif" />

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -95,12 +95,13 @@
 - ● [`anycopy/`](anycopy/) ([README](./anycopy/README.md))
   - `/anycopy` mirrors all behaviors of Pi's native `/tree` while adding a live, syntax-highlighted preview of each node's content, the ability to copy any node(s) to the clipboard, and optional node creation timestamps
   - `Enter` navigates to focused node (same semantics as `/tree`, including the summary chooser and `branchSummary.skipPrompt` support)
-  - `Shift+A` selects nodes, `Shift+R` extends an inclusive range, and `Shift+C` copies the selection. Tool-result nodes include their originating call
-  - `Tab` toggles tree-focused and preview-focused layouts. `?` shows effective native tree and anycopy bindings
+  - `Shift+A` selects nodes, `Shift+R` adds an inclusive range, and `Shift+C` copies while retaining the selection. Tool-result nodes include their originating call
+  - An optional copy-only shortcut preserves the editor draft. `Tab` toggles tree-focused and preview-focused layouts. `?` shows effective native tree and anycopy bindings
   - `Shift+Up`/`Down` scroll preview by line, `Shift+PageUp`/`PageDown` page preview
   - Single-node copies use just the node's content; role prefixes are only added when copying 2+ nodes
+  - Custom entries use readable labeled preview and clipboard output with local-time timestamp formatting
   - Multi-selected nodes are auto-sorted chronologically (by tree position)
-  - Configurable in `anycopy/config.json`: `treeFilterMode` (initial filter mode), `keys` (overlay keybindings)
+  - `anycopy/config.json` is the canonical configuration file for the shortcut, hint mode, layout ratios, tree filter, fold persistence, and overlay keys
 
 <p align="center">
   <img width="450" alt="anycopy demo" src="https://raw.githubusercontent.com/w-winter/dot314/main/assets/anycopy-demo.gif" />

--- a/extensions/anycopy/CHANGELOG.md
+++ b/extensions/anycopy/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Fixed
 - Status hints wrap to the viewport width without dropping actions
+- Tool-call lookup handles deep result chains, and large arguments are bounded in previews
+- Clipboard failures are reported instead of showing a false success message
+- Package staging is cleaned before publishing so removed interaction modules are not included
 
 ## [0.3.4] - 2026-08-13
 

--- a/extensions/anycopy/CHANGELOG.md
+++ b/extensions/anycopy/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Tool-result nodes now preview and copy their originating tool call together with the result
 - Key hints spell modifier names out
 
+### Fixed
+- Status hints wrap to the viewport width without dropping actions
+
 ## [0.3.4] - 2026-08-13
 
 ### Fixed

--- a/extensions/anycopy/CHANGELOG.md
+++ b/extensions/anycopy/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Additive inclusive range selection on `Shift+R`
 - Two configurable tree and preview focus layouts toggled with `Tab`
-- Effective keybinding help on `?`, including native tree movement, filtering, folding, and anycopy actions
+- Keybinding help on `?`, including native tree movement, filtering, folding, and anycopy actions
 - Optional copy-only shortcut that preserves the current editor draft
 - Configurable full and compact inline hints
 - Readable custom-entry previews and clipboard output with local-time timestamp formatting
@@ -16,9 +16,11 @@
 
 ### Fixed
 - Status hints wrap to the viewport width without dropping actions
-- Tool-call lookup handles deep result chains, and large arguments are bounded in previews
+- Tool-call context remains available for results deep in the session tree, and large arguments no longer overwhelm previews
 - Clipboard failures are reported instead of showing a false success message
-- Package staging is cleaned before publishing so removed interaction modules are not included
+- Published packages no longer retain stale anycopy modules from previous builds
+
+Contributed by [@AdamsGH](https://github.com/AdamsGH).
 
 ## [0.3.4] - 2026-08-13
 

--- a/extensions/anycopy/CHANGELOG.md
+++ b/extensions/anycopy/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Inclusive range selection on `Shift+R`
+- Two configurable tree and preview focus layouts toggled with `Tab`
+- Effective keybinding help on `?`, including native tree movement, filtering, folding, and anycopy actions
+
+### Changed
+- Tool-result nodes now preview and copy their originating tool call together with the result
+- Key hints spell modifier names out
+
 ## [0.3.4] - 2026-08-13
 
 ### Fixed

--- a/extensions/anycopy/CHANGELOG.md
+++ b/extensions/anycopy/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## [Unreleased]
 
 ### Added
-- Inclusive range selection on `Shift+R`
+- Additive inclusive range selection on `Shift+R`
 - Two configurable tree and preview focus layouts toggled with `Tab`
 - Effective keybinding help on `?`, including native tree movement, filtering, folding, and anycopy actions
+- Optional copy-only shortcut that preserves the current editor draft
+- Configurable full and compact inline hints
+- Readable custom-entry previews and clipboard output with local-time timestamp formatting
 
 ### Changed
 - Tool-result nodes now preview and copy their originating tool call together with the result

--- a/extensions/anycopy/README.md
+++ b/extensions/anycopy/README.md
@@ -16,13 +16,16 @@ Defaults (customizable in `config.json`):
 |-----|--------|
 | `Enter` | Navigate to the focused node (same semantics as `/tree`) |
 | `Shift+A` | Select/unselect focused node for copy |
-| `Shift+C` | Copy selected nodes, or the focused node if nothing is selected |
+| `Shift+C` | Copy selected nodes, or the focused node if nothing is selected. Tool results include the originating call |
 | `Shift+X` | Clear selection |
+| `Shift+R` | Start or finish inclusive range selection |
+| `Tab` | Toggle between tree-focused and preview-focused layouts |
 | `Shift+L` | Label node (native tree behavior) |
 | `Shift+T` | Toggle label timestamps for labeled nodes |
 | `Shift+Ctrl+T` | Toggle node creation timestamps |
 | `Shift+Up` / `Shift+Down` | Scroll node preview by line |
 | `Shift+PageUp` / `Shift+PageDown` | Page through node preview |
+| `?` | Show every effective native tree and anycopy action |
 | `Esc` | Close |
 
 Notes:
@@ -32,6 +35,11 @@ Notes:
 - Escaping the summary chooser reopens `/anycopy` with focus restored to the node you tried to select
 - Cancelling the custom summarization editor returns to the summary chooser
 - If no nodes are selected, `Shift+C` copies the focused node
+- Tool-result previews always show the originating tool name and arguments above the result. Copying the node includes both the call and result
+- `Shift+R` anchors a range at the focused node. Tree movement extends or shrinks the inclusive range, toggling every node against its state when the range started
+- Search, filter, and fold changes finish an active range while preserving its selected nodes
+- `Tab` switches directly between the tree-focused and preview-focused layouts. Both panes remain visible according to their configured ratios
+- `?` lists every effective native tree and anycopy binding. It omits native actions that anycopy does not implement
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
@@ -53,12 +61,18 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
 - `treeFilterMode`: initial tree filter mode when opening `/anycopy`; defaults to `default` to match `/tree`
   - one of: `default` | `no-tools` | `user-only` | `labeled-only` | `all`
 - `persistFoldState`: whether `/anycopy` persists folded branches across reopenings and later sessions; defaults to `true`; when disabled, `/anycopy` does not read or write hidden fold-state session entries
-- `keys`: keybindings used inside the `/anycopy` overlay for copy/preview actions and the creation timestamp toggle
+- `layout.treeFocusTreeRatio`: fraction of pane rows used by the tree in tree-focused mode
+- `layout.previewFocusTreeRatio`: fraction of pane rows used by the tree in preview-focused mode
+- `keys`: keybindings used inside the `/anycopy` overlay
 
 ```json
 {
   "treeFilterMode": "default",
   "persistFoldState": true,
+  "layout": {
+    "treeFocusTreeRatio": 0.85,
+    "previewFocusTreeRatio": 0.15
+  },
   "keys": {
     "toggleSelect": "shift+a",
     "copy": "shift+c",
@@ -68,7 +82,10 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
     "scrollUp": "shift+up",
     "scrollDown": "shift+down",
     "pageUp": "shift+pageup",
-    "pageDown": "shift+pagedown"
+    "pageDown": "shift+pagedown",
+    "togglePaneFocus": "tab",
+    "toggleRangeSelection": "shift+r",
+    "help": "?"
   }
 }
 ```

--- a/extensions/anycopy/README.md
+++ b/extensions/anycopy/README.md
@@ -25,7 +25,7 @@ Defaults (customizable in `config.json`):
 | `Shift+Ctrl+T` | Toggle node creation timestamps |
 | `Shift+Up` / `Shift+Down` | Scroll node preview by line |
 | `Shift+PageUp` / `Shift+PageDown` | Page through node preview |
-| `?` | Show every effective native tree and anycopy action |
+| `?` | Show available anycopy and native tree keybindings |
 | `Esc` | Close |
 
 Notes:
@@ -39,9 +39,9 @@ Notes:
 - `Shift+R` anchors a range at the focused node. Tree movement extends or shrinks the inclusive range and adds every node in that range to the existing selection
 - Search, filter, and fold changes finish an active range while preserving its selected nodes
 - `Tab` switches directly between the tree-focused and preview-focused layouts. Both panes remain visible according to their configured ratios
-- `?` lists every effective native tree and anycopy binding. It omits native actions that anycopy does not implement
-- An optional global shortcut opens anycopy without clearing the editor draft. This copy-only mode keeps `Shift+C` unchanged, while `Enter` explains that navigation requires command-opened `/anycopy`
-- Custom session entries use readable labeled content in previews and clipboard output. Numeric timestamp fields ending in `At` use the local time zone
+- `?` lists the anycopy and native tree keybindings available in the overlay
+- An optional Pi shortcut opens anycopy without clearing the editor draft. This copy-only view keeps `Shift+C` available; use `/anycopy` when you want `Enter` to navigate the session tree
+- Custom session entries use readable labeled content in previews and clipboard output. Timestamps in custom session entries use the local time zone
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
@@ -63,10 +63,10 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
 - `treeFilterMode`: initial tree filter mode when opening `/anycopy`; defaults to `default` to match `/tree`
   - one of: `default` | `no-tools` | `user-only` | `labeled-only` | `all`
 - `persistFoldState`: whether `/anycopy` persists folded branches across reopenings and later sessions; defaults to `true`; when disabled, `/anycopy` does not read or write hidden fold-state session entries
-- `shortcut`: optional global shortcut that opens copy-only anycopy without clearing the current editor draft. Set it to a key such as `ctrl+shift+c`, or leave it as `null`
-- `hints.mode`: `full` shows every inline action, while `compact` keeps one status row with the help and Enter actions
-- `layout.treeFocusTreeRatio`: fraction of pane rows used by the tree in tree-focused mode
-- `layout.previewFocusTreeRatio`: fraction of pane rows used by the tree in preview-focused mode
+- `shortcut`: optional Pi shortcut that opens copy-only anycopy without clearing the current editor draft. Set it to a key such as `ctrl+shift+c`, or leave it as `null`
+- `hints.mode`: `full` displays shortcut hints below the tree, while `compact` uses one status row for help and Enter guidance
+- `layout.treeFocusTreeRatio`: fraction of pane rows used by the tree in tree-focused mode; must be greater than `0` and less than `1`
+- `layout.previewFocusTreeRatio`: fraction of pane rows used by the tree in preview-focused mode; must be greater than `0` and less than `1`
 - `keys`: keybindings used inside the `/anycopy` overlay
 
 ```json

--- a/extensions/anycopy/README.md
+++ b/extensions/anycopy/README.md
@@ -36,10 +36,12 @@ Notes:
 - Cancelling the custom summarization editor returns to the summary chooser
 - If no nodes are selected, `Shift+C` copies the focused node
 - Tool-result previews always show the originating tool name and arguments above the result. Copying the node includes both the call and result
-- `Shift+R` anchors a range at the focused node. Tree movement extends or shrinks the inclusive range, toggling every node against its state when the range started
+- `Shift+R` anchors a range at the focused node. Tree movement extends or shrinks the inclusive range and adds every node in that range to the existing selection
 - Search, filter, and fold changes finish an active range while preserving its selected nodes
 - `Tab` switches directly between the tree-focused and preview-focused layouts. Both panes remain visible according to their configured ratios
 - `?` lists every effective native tree and anycopy binding. It omits native actions that anycopy does not implement
+- An optional global shortcut opens anycopy without clearing the editor draft. This copy-only mode keeps `Shift+C` unchanged, while `Enter` explains that navigation requires command-opened `/anycopy`
+- Custom session entries use readable labeled content in previews and clipboard output. Numeric timestamp fields ending in `At` use the local time zone
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
@@ -61,6 +63,8 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
 - `treeFilterMode`: initial tree filter mode when opening `/anycopy`; defaults to `default` to match `/tree`
   - one of: `default` | `no-tools` | `user-only` | `labeled-only` | `all`
 - `persistFoldState`: whether `/anycopy` persists folded branches across reopenings and later sessions; defaults to `true`; when disabled, `/anycopy` does not read or write hidden fold-state session entries
+- `shortcut`: optional global shortcut that opens copy-only anycopy without clearing the current editor draft. Set it to a key such as `ctrl+shift+c`, or leave it as `null`
+- `hints.mode`: `full` shows every inline action, while `compact` keeps one status row with the help and Enter actions
 - `layout.treeFocusTreeRatio`: fraction of pane rows used by the tree in tree-focused mode
 - `layout.previewFocusTreeRatio`: fraction of pane rows used by the tree in preview-focused mode
 - `keys`: keybindings used inside the `/anycopy` overlay
@@ -69,6 +73,10 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
 {
   "treeFilterMode": "default",
   "persistFoldState": true,
+  "shortcut": null,
+  "hints": {
+    "mode": "full"
+  },
   "layout": {
     "treeFocusTreeRatio": 0.85,
     "previewFocusTreeRatio": 0.15

--- a/extensions/anycopy/config.json
+++ b/extensions/anycopy/config.json
@@ -1,6 +1,10 @@
 {
   "treeFilterMode": "no-tools",
   "persistFoldState": true,
+  "layout": {
+    "treeFocusTreeRatio": 0.85,
+    "previewFocusTreeRatio": 0.15
+  },
   "keys": {
     "toggleSelect": "shift+a",
     "copy": "shift+c",
@@ -10,6 +14,9 @@
     "scrollUp": "shift+up",
     "scrollDown": "shift+down",
     "pageUp": "shift+pageup",
-    "pageDown": "shift+pagedown"
+    "pageDown": "shift+pagedown",
+    "togglePaneFocus": "tab",
+    "toggleRangeSelection": "shift+r",
+    "help": "?"
   }
 }

--- a/extensions/anycopy/config.json
+++ b/extensions/anycopy/config.json
@@ -1,6 +1,10 @@
 {
   "treeFilterMode": "no-tools",
   "persistFoldState": true,
+  "shortcut": null,
+  "hints": {
+    "mode": "full"
+  },
   "layout": {
     "treeFocusTreeRatio": 0.85,
     "previewFocusTreeRatio": 0.15

--- a/extensions/anycopy/custom-entry.ts
+++ b/extensions/anycopy/custom-entry.ts
@@ -33,7 +33,7 @@ const formatLocalDate = (date: Date): string =>
 
 const formatScalar = (key: string, value: unknown): string => {
 	if (typeof value === "number") {
-		if (/at$/i.test(key) && Number.isFinite(value)) {
+		if (key.endsWith("At") && Number.isFinite(value)) {
 			const date = new Date(value);
 			if (!Number.isNaN(date.getTime())) return formatLocalDate(date);
 		}

--- a/extensions/anycopy/custom-entry.ts
+++ b/extensions/anycopy/custom-entry.ts
@@ -1,0 +1,98 @@
+const PREVIEW_LABELS: Record<string, string> = {
+	capturedAt: "Captured at",
+	promptKind: "Prompt kind",
+	chars: "Characters",
+	sha256: "SHA-256",
+	contextFiles: "Context files",
+	entryType: "Entry type",
+};
+
+const ARRAY_ITEM_IDENTITY_KEYS = ["path", "name", "title", "id", "type"];
+
+const humanizeKey = (key: string): string => {
+	const known = PREVIEW_LABELS[key];
+	if (known) return known;
+	const words = key
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.replace(/[_-]+/g, " ")
+		.toLowerCase();
+	return words.charAt(0).toUpperCase() + words.slice(1);
+};
+
+const formatLocalDate = (date: Date): string =>
+	new Intl.DateTimeFormat("en-GB", {
+		day: "2-digit",
+		month: "short",
+		year: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hourCycle: "h23",
+		timeZoneName: "short",
+	}).format(date);
+
+const formatScalar = (key: string, value: unknown): string => {
+	if (typeof value === "number") {
+		if (/at$/i.test(key) && Number.isFinite(value)) {
+			const date = new Date(value);
+			if (!Number.isNaN(date.getTime())) return formatLocalDate(date);
+		}
+		return /chars?|count|size/i.test(key) ? value.toLocaleString("en-US") : String(value);
+	}
+	if (typeof value === "boolean") return value ? "true" : "false";
+	if (value === null) return "null";
+	return String(value);
+};
+
+const formatLabel = (label: string, markdown: boolean, suffix = "", colon = true): string =>
+	markdown ? `**${label}${suffix}${colon ? ":" : ""}**` : `${label}${suffix}${colon ? ":" : ""}`;
+
+const renderValue = (value: unknown, depth: number, markdown: boolean, key = "value"): string[] => {
+	const indent = "  ".repeat(depth);
+	if (Array.isArray(value)) {
+		if (value.length === 0) return [`${indent}${markdown ? "_(empty)_" : "(empty)"}`];
+		return value.flatMap((item, index) => {
+			if (typeof item !== "object" || item === null) {
+				return [`${indent}${index + 1}. ${formatScalar(key, item)}`];
+			}
+			const record = item as Record<string, unknown>;
+			const identityKey = ARRAY_ITEM_IDENTITY_KEYS.find((candidate) => {
+				const identity = record[candidate];
+				return typeof identity === "string" || typeof identity === "number";
+			});
+			if (!identityKey) return [`${indent}${index + 1}.`, ...renderValue(record, depth + 1, markdown)];
+			const identity = formatScalar(identityKey, record[identityKey]);
+			const remainder = Object.fromEntries(Object.entries(record).filter(([childKey]) => childKey !== identityKey));
+			const remainderLines = Object.keys(remainder).length > 0 ? renderValue(remainder, depth + 1, markdown) : [];
+			return [`${indent}${index + 1}. ${identity}`, ...remainderLines];
+		});
+	}
+	if (typeof value === "object" && value !== null) {
+		const entries = Object.entries(value as Record<string, unknown>);
+		if (entries.length === 0) return [`${indent}${markdown ? "_(empty)_" : "(empty)"}`];
+		return entries.flatMap(([childKey, childValue]) => {
+			const label = humanizeKey(childKey);
+			if (typeof childValue === "object" && childValue !== null) {
+				const suffix = Array.isArray(childValue) ? ` (${childValue.length})` : "";
+				return [
+					`${indent}${formatLabel(label, markdown, suffix, false)}`,
+					...renderValue(childValue, depth + 1, markdown, childKey),
+				];
+			}
+			return [`${indent}${formatLabel(label, markdown)} ${formatScalar(childKey, childValue)}`];
+		});
+	}
+	return [`${indent}${formatScalar(key, value)}`];
+};
+
+const formatCustomEntry = (customType: string, data: unknown, markdown: boolean): string => {
+	const header = markdown ? `**Custom entry:** \`${customType}\`` : `Custom entry: ${customType}`;
+	if (data === undefined) return header;
+	return [header, "", ...renderValue(data, 0, markdown)].join("\n");
+};
+
+export const formatCustomEntryContent = (customType: string, data: unknown): string =>
+	formatCustomEntry(customType, data, false);
+
+export const formatCustomEntryPreview = (customType: string, data: unknown): string =>
+	formatCustomEntry(customType, data, true);

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -33,6 +33,7 @@ import {
 	matchesKey,
 	truncateToWidth,
 	visibleWidth,
+	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import type { Focusable } from "@earendil-works/pi-tui";
 
@@ -46,6 +47,7 @@ import { AnycopyKeyHelp } from "./key-help.ts";
 import { formatConfiguredKey, getKeyHelpPreferredWidth, type KeyHelpRow } from "./key-help-data.ts";
 import { applyInclusiveRangeSelection, togglePaneFocus, type PaneFocus } from "./interaction-state.ts";
 import { getPreviewPageStep, getPreviewWindow } from "./preview-window.ts";
+import { renderStatusHints } from "./status-hints.ts";
 import { formatCompactTimestamp, getEntryTimestampMs } from "./timestamps.ts";
 import { formatToolCallResultForClipboard, getToolName, resolveToolCallFromParents } from "./tool-call-copy.ts";
 import { buildNodeOrder } from "./tree-order.ts";
@@ -696,17 +698,24 @@ class anycopyOverlay implements Focusable {
 		}
 
 		const key = formatConfiguredKey;
-		const hint =
-			`  ${key(this.keys.scrollUp)}/${key(this.keys.scrollDown)}: scroll preview` +
-			` · ${key(this.keys.pageUp)}/${key(this.keys.pageDown)}: page preview` +
-			` · Enter: navigate` +
-			` · ${key(this.keys.toggleRangeSelection)}: range` +
-			` · ${key(this.keys.toggleSelect)}: select` +
-			` · ${key(this.keys.copy)}: copy` +
-			` · ${key(this.keys.clear)}: clear` +
-			` · ${key(this.keys.togglePaneFocus)}: layout` +
-			` · ${key(this.keys.help)}: help`;
-		lines.push(truncateToWidth(this.theme.fg("dim", hint), width));
+		lines.push(
+			...renderStatusHints(
+				[
+					`${key(this.keys.scrollUp)}/${key(this.keys.scrollDown)}: scroll preview`,
+					`${key(this.keys.pageUp)}/${key(this.keys.pageDown)}: page preview`,
+					"Enter: navigate",
+					`${key(this.keys.toggleRangeSelection)}: range`,
+					`${key(this.keys.toggleSelect)}: select`,
+					`${key(this.keys.copy)}: copy`,
+					`${key(this.keys.clear)}: clear`,
+					`${key(this.keys.togglePaneFocus)}: layout`,
+					`${key(this.keys.help)}: help`,
+				],
+				width,
+				wrapTextWithAnsi,
+				(text) => this.theme.fg("dim", text),
+			),
+		);
 
 		return lines;
 	}

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -18,7 +18,12 @@
  *   Esc       - close
  */
 
-import type { ExtensionAPI, ExtensionCommandContext, SessionEntry } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	KeybindingsManager,
+	SessionEntry,
+} from "@earendil-works/pi-coding-agent";
 import {
 	copyToClipboard,
 	getLanguageFromPath,
@@ -28,7 +33,6 @@ import {
 } from "@earendil-works/pi-coding-agent";
 
 import {
-	getKeybindings,
 	Markdown,
 	matchesKey,
 	truncateToWidth,
@@ -44,12 +48,17 @@ import { fileURLToPath } from "url";
 
 import { createAnycopyEnterNavigationLauncher, runAnycopyEnterNavigation } from "./enter-navigation.ts";
 import { getKeyHelpWindow, renderKeyHelpLines } from "./key-help.ts";
-import { formatConfiguredKey, type KeyHelpRow } from "./key-help-data.ts";
+import { buildKeyHelpRows, formatConfiguredKey, type KeyHelpRow } from "./key-help-data.ts";
 import { applyInclusiveRangeSelection, togglePaneFocus, type PaneFocus } from "./interaction-state.ts";
 import { getPreviewPageStep, getPreviewWindow } from "./preview-window.ts";
 import { renderStatusHints } from "./status-hints.ts";
 import { formatCompactTimestamp, getEntryTimestampMs } from "./timestamps.ts";
-import { formatToolCallResultForClipboard, getToolName, resolveToolCallFromParents } from "./tool-call-copy.ts";
+import {
+	formatJsonForDisplay,
+	formatToolCallResultForClipboard,
+	getToolName,
+	resolveToolCallFromParents,
+} from "./tool-call-copy.ts";
 import { buildNodeOrder } from "./tree-order.ts";
 import {
 	getAnycopyRenderHeight,
@@ -84,6 +93,7 @@ type anycopyTreeListInternals = {
 };
 
 type MatchesKeyId = Parameters<typeof matchesKey>[1];
+type EffectiveKeybindingId = Parameters<KeybindingsManager["getKeys"]>[0];
 
 type anycopyKeyConfig = {
 	toggleSelect: string;
@@ -355,46 +365,6 @@ const getTreeListInternals = (treeList: anycopyTreeList): anycopyTreeListInterna
 	return treeList as unknown as anycopyTreeListInternals;
 };
 
-type EffectiveKeybindings = ReturnType<typeof getKeybindings>;
-type EffectiveKeybindingId = Parameters<EffectiveKeybindings["getKeys"]>[0];
-
-const getEffectiveKeys = (keybindings: EffectiveKeybindings, ...ids: string[]): string[] =>
-	[...new Set(ids.flatMap((id) => keybindings.getKeys(id as EffectiveKeybindingId).map(String)))];
-
-const buildKeyHelpRows = (
-	keybindings: EffectiveKeybindings,
-	keys: anycopyKeyConfig,
-): KeyHelpRow[] => [
-	{ keys: getEffectiveKeys(keybindings, "tui.select.up"), label: "move up" },
-	{ keys: getEffectiveKeys(keybindings, "tui.select.down"), label: "move down" },
-	{ keys: getEffectiveKeys(keybindings, "tui.editor.cursorLeft", "tui.select.pageUp"), label: "page tree up" },
-	{ keys: getEffectiveKeys(keybindings, "tui.editor.cursorRight", "tui.select.pageDown"), label: "page tree down" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.foldOrUp"), label: "fold branch or jump up" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.unfoldOrDown"), label: "unfold branch or jump down" },
-	{ keys: getEffectiveKeys(keybindings, "tui.select.confirm"), label: "navigate to focused node" },
-	{ keys: getEffectiveKeys(keybindings, "tui.select.cancel"), label: "clear search or close" },
-	{ keys: getEffectiveKeys(keybindings, "tui.editor.deleteCharBackward"), label: "delete search character" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.editLabel"), label: "edit label" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.default"), label: "use default filter" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.noTools"), label: "toggle no-tools filter" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.userOnly"), label: "toggle user-only filter" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.labeledOnly"), label: "toggle labeled-only filter" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.all"), label: "toggle all-entries filter" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.cycleForward"), label: "cycle filter forward" },
-	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.cycleBackward"), label: "cycle filter backward" },
-	{ keys: ["printable text"], label: "search visible nodes" },
-	{ keys: [keys.toggleSelect], label: "toggle focused node selection" },
-	{ keys: [keys.toggleRangeSelection], label: "start or finish range selection" },
-	{ keys: [keys.copy], label: "copy focused or selected nodes" },
-	{ keys: [keys.clear], label: "clear selection" },
-	{ keys: [keys.togglePaneFocus], label: "toggle tree or preview focus" },
-	{ keys: [keys.scrollUp, keys.scrollDown], label: "scroll preview" },
-	{ keys: [keys.pageUp, keys.pageDown], label: "page preview" },
-	{ keys: [keys.toggleLabelTimestamps], label: "toggle label timestamps" },
-	{ keys: [keys.toggleEntryTimestamps], label: "toggle entry timestamps" },
-	{ keys: [keys.help], label: "show or close this help" },
-];
-
 /** Clipboard text omits role prefix for a single node and includes it for multi-node copies
  * The preview pane is truncated for performance, while the clipboard copy is not
  */
@@ -426,6 +396,7 @@ class anycopyOverlay implements Focusable {
 	private helpOffset = 0;
 	private helpLineCount = 0;
 	private helpPageSize = 1;
+	private disposed = false;
 	private previewCache: {
 		entryId: string;
 		width: number;
@@ -440,6 +411,7 @@ class anycopyOverlay implements Focusable {
 		private keys: anycopyKeyConfig,
 		private layoutRatios: PaneLayoutRatios,
 		private helpRows: readonly KeyHelpRow[],
+		private keybindings: KeybindingsManager,
 		private onExplicitFoldMutation: ((
 			beforeTransientFoldedNodeIds: string[],
 			afterTransientFoldedNodeIds: string[],
@@ -516,8 +488,7 @@ class anycopyOverlay implements Focusable {
 			return;
 		}
 
-		const keybindings = getKeybindings();
-		if (keybindings.matches(data, "app.tree.toggleLabelTimestamp")) {
+		if (this.keybindings.matches(data, "app.tree.toggleLabelTimestamp")) {
 			return;
 		}
 
@@ -548,7 +519,8 @@ class anycopyOverlay implements Focusable {
 		const beforeFocusedId = this.getFocusedNode()?.entry.id;
 		const shouldTrackExplicitFoldMutation =
 			this.onExplicitFoldMutation !== null &&
-			(keybindings.matches(data, "app.tree.foldOrUp") || keybindings.matches(data, "app.tree.unfoldOrDown"));
+			(this.keybindings.matches(data, "app.tree.foldOrUp") ||
+				this.keybindings.matches(data, "app.tree.unfoldOrDown"));
 		const beforeTransientFoldedNodeIds = shouldTrackExplicitFoldMutation ? getSelectorFoldedNodeIds(this.selector) : null;
 
 		this.selector.handleInput(data);
@@ -585,11 +557,10 @@ class anycopyOverlay implements Focusable {
 			return;
 		}
 
-		const keybindings = getKeybindings();
-		if (keybindings.matches(data, "tui.select.up")) this.helpOffset -= 1;
-		else if (keybindings.matches(data, "tui.select.down")) this.helpOffset += 1;
-		else if (keybindings.matches(data, "tui.select.pageUp")) this.helpOffset -= this.helpPageSize;
-		else if (keybindings.matches(data, "tui.select.pageDown")) this.helpOffset += this.helpPageSize;
+		if (this.keybindings.matches(data, "tui.select.up")) this.helpOffset -= 1;
+		else if (this.keybindings.matches(data, "tui.select.down")) this.helpOffset += 1;
+		else if (this.keybindings.matches(data, "tui.select.pageUp")) this.helpOffset -= this.helpPageSize;
+		else if (this.keybindings.matches(data, "tui.select.pageDown")) this.helpOffset += this.helpPageSize;
 		else return;
 
 		this.helpOffset = Math.max(0, Math.min(this.helpOffset, Math.max(0, this.helpLineCount - this.helpPageSize)));
@@ -639,6 +610,7 @@ class anycopyOverlay implements Focusable {
 	}
 
 	private flash(message: string): void {
+		if (this.disposed) return;
 		this.flashMessage = message;
 		if (this.flashTimer) clearTimeout(this.flashTimer);
 		this.flashTimer = setTimeout(() => {
@@ -705,8 +677,11 @@ class anycopyOverlay implements Focusable {
 				return oa - ob;
 			});
 
-		copyToClipboard(buildClipboardText(nodes, nodeById));
-		this.flash(`Copied ${nodes.length} ${pluralizeNode(nodes.length)} to clipboard`);
+		void copyToClipboard(buildClipboardText(nodes, nodeById))
+			.then(() => this.flash(`Copied ${nodes.length} ${pluralizeNode(nodes.length)} to clipboard`))
+			.catch((error: unknown) => {
+				this.flash(`Copy failed: ${error instanceof Error ? error.message : String(error)}`);
+			});
 	}
 
 	private renderStatusBar(width: number): string[] {
@@ -769,11 +744,15 @@ class anycopyOverlay implements Focusable {
 		const clipped = clipTextForPreview(content);
 		const resultLines = renderPreviewBodyLines(clipped, focused.entry, width, this.theme, this.nodeById);
 		const invocation = resolveToolCallFromParents(focused.entry, this.nodeById);
+		const argumentLines = invocation
+			? highlightCode(clipTextForPreview(formatJsonForDisplay(invocation.arguments)), "json")
+				.map((line) => truncateToWidth(line, width))
+			: [];
 		const rendered = invocation
 			? [
 				truncateToWidth(`${this.theme.fg("muted", "Tool")}  ${this.theme.fg("accent", invocation.name)}`, width),
 				truncateToWidth(this.theme.fg("muted", "Arguments"), width),
-				...highlightCode(JSON.stringify(invocation.arguments, null, 2), "json").map((line) => truncateToWidth(line, width)),
+				...argumentLines,
 				this.theme.fg("dim", "─".repeat(Math.max(1, width))),
 				...resultLines,
 			]
@@ -879,8 +858,15 @@ class anycopyOverlay implements Focusable {
 			...bodyLines.slice(window.offset, window.end),
 		];
 		while (output.length < height - 1) output.push("");
+		const helpScrollKeys = [...new Set([
+			...this.keybindings.getKeys("tui.select.up"),
+			...this.keybindings.getKeys("tui.select.down"),
+			...this.keybindings.getKeys("tui.select.pageUp"),
+			...this.keybindings.getKeys("tui.select.pageDown"),
+		])].map(String).map(formatConfiguredKey).join("/");
+		const helpScrollHint = helpScrollKeys ? `${helpScrollKeys} scroll · ` : "";
 		const range = bodyLines.length > window.pageSize
-			? `${window.offset + 1}-${window.end} of ${bodyLines.length} · Up/Down/PageUp/PageDown scroll · `
+			? `${window.offset + 1}-${window.end} of ${bodyLines.length} · ${helpScrollHint}`
 			: "";
 		output.push(
 			this.renderPreviewDivider(
@@ -918,6 +904,7 @@ class anycopyOverlay implements Focusable {
 	}
 
 	dispose(): void {
+		this.disposed = true;
 		if (this.flashTimer) {
 			clearTimeout(this.flashTimer);
 			this.flashTimer = null;
@@ -962,7 +949,10 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				done();
 			};
 			const getRenderHeight = (): number => getAnycopyRenderHeight(tui.terminal?.rows ?? 40);
-			const helpRows = buildKeyHelpRows(keybindings, keys);
+			const helpRows = buildKeyHelpRows(
+				(id) => keybindings.getKeys(id as EffectiveKeybindingId).map(String),
+				keys,
+			);
 			const treeTermHeight = getAnycopyTreeHeight(getRenderHeight());
 			const nodeById = buildNodeMap(initialTree);
 			const validNodeIds = new Set(nodeById.keys());
@@ -1060,6 +1050,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				keys,
 				layoutRatios,
 				helpRows,
+				keybindings,
 				persistFoldState ? handleExplicitFoldMutation : null,
 				getRenderHeight,
 				() => tui.requestRender(),

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -43,8 +43,8 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 import { createAnycopyEnterNavigationLauncher, runAnycopyEnterNavigation } from "./enter-navigation.ts";
-import { AnycopyKeyHelp } from "./key-help.ts";
-import { formatConfiguredKey, getKeyHelpPreferredWidth, type KeyHelpRow } from "./key-help-data.ts";
+import { getKeyHelpWindow, renderKeyHelpLines } from "./key-help.ts";
+import { formatConfiguredKey, type KeyHelpRow } from "./key-help-data.ts";
 import { applyInclusiveRangeSelection, togglePaneFocus, type PaneFocus } from "./interaction-state.ts";
 import { getPreviewPageStep, getPreviewWindow } from "./preview-window.ts";
 import { renderStatusHints } from "./status-hints.ts";
@@ -422,6 +422,10 @@ class anycopyOverlay implements Focusable {
 	private _focused = false;
 	private previewScrollOffset = 0;
 	private lastPreviewHeight = 0;
+	private helpVisible = false;
+	private helpOffset = 0;
+	private helpLineCount = 0;
+	private helpPageSize = 1;
 	private previewCache: {
 		entryId: string;
 		width: number;
@@ -435,7 +439,7 @@ class anycopyOverlay implements Focusable {
 		private nodeById: Map<string, SessionTreeNode>,
 		private keys: anycopyKeyConfig,
 		private layoutRatios: PaneLayoutRatios,
-		private openHelp: () => void,
+		private helpRows: readonly KeyHelpRow[],
 		private onExplicitFoldMutation: ((
 			beforeTransientFoldedNodeIds: string[],
 			afterTransientFoldedNodeIds: string[],
@@ -458,6 +462,11 @@ class anycopyOverlay implements Focusable {
 	}
 
 	handleInput(data: string): void {
+		if (this.helpVisible) {
+			this.handleHelpInput(data);
+			return;
+		}
+
 		if (this.isEditingNodeLabel()) {
 			this.selector.handleInput(data);
 			this.requestRender();
@@ -465,7 +474,9 @@ class anycopyOverlay implements Focusable {
 		}
 
 		if (matchesKey(data, this.keys.help as MatchesKeyId)) {
-			this.openHelp();
+			this.helpVisible = true;
+			this.helpOffset = 0;
+			this.requestRender();
 			return;
 		}
 		if (matchesKey(data, this.keys.togglePaneFocus as MatchesKeyId)) {
@@ -563,6 +574,25 @@ class anycopyOverlay implements Focusable {
 			this.onExplicitFoldMutation?.(beforeTransientFoldedNodeIds, getSelectorFoldedNodeIds(this.selector));
 		}
 
+		this.requestRender();
+	}
+
+	private handleHelpInput(data: string): void {
+		if (matchesKey(data, this.keys.help as MatchesKeyId) || matchesKey(data, "escape")) {
+			this.helpVisible = false;
+			this.helpOffset = 0;
+			this.requestRender();
+			return;
+		}
+
+		const keybindings = getKeybindings();
+		if (keybindings.matches(data, "tui.select.up")) this.helpOffset -= 1;
+		else if (keybindings.matches(data, "tui.select.down")) this.helpOffset += 1;
+		else if (keybindings.matches(data, "tui.select.pageUp")) this.helpOffset -= this.helpPageSize;
+		else if (keybindings.matches(data, "tui.select.pageDown")) this.helpOffset += this.helpPageSize;
+		else return;
+
+		this.helpOffset = Math.max(0, Math.min(this.helpOffset, Math.max(0, this.helpLineCount - this.helpPageSize)));
 		this.requestRender();
 	}
 
@@ -824,6 +854,43 @@ class anycopyOverlay implements Focusable {
 		return selectorLines;
 	}
 
+	private renderHelpPreview(width: number, height: number): string[] {
+		const bodyLines = renderKeyHelpLines(
+			this.helpRows,
+			width,
+			wrapTextWithAnsi,
+			(text) => this.theme.fg("dim", text),
+		);
+		const window = getKeyHelpWindow(bodyLines.length, height, this.helpOffset);
+		this.helpOffset = window.offset;
+		this.helpLineCount = bodyLines.length;
+		this.helpPageSize = window.pageSize;
+
+		if (height === 1) return [this.renderPreviewDivider(width, "Key bindings")];
+		if (height === 2) {
+			return [
+				this.renderPreviewDivider(width, "Key bindings"),
+				this.renderPreviewDivider(width, `${formatConfiguredKey(this.keys.help)}/Esc close help`),
+			];
+		}
+
+		const output = [
+			this.renderPreviewDivider(width, "Key bindings"),
+			...bodyLines.slice(window.offset, window.end),
+		];
+		while (output.length < height - 1) output.push("");
+		const range = bodyLines.length > window.pageSize
+			? `${window.offset + 1}-${window.end} of ${bodyLines.length} · Up/Down/PageUp/PageDown scroll · `
+			: "";
+		output.push(
+			this.renderPreviewDivider(
+				width,
+				`${range}${formatConfiguredKey(this.keys.help)}/Esc close help`,
+			),
+		);
+		return output.slice(0, height);
+	}
+
 	render(width: number): string[] {
 		const height = this.getRenderHeight();
 		const output: string[] = [];
@@ -838,7 +905,13 @@ class anycopyOverlay implements Focusable {
 
 		output.push(...selectorLines, ...statusLines);
 		const previewHeight = Math.max(0, height - output.length);
-		if (previewHeight > 0) output.push(...this.renderPreview(width, previewHeight));
+		if (previewHeight > 0) {
+			output.push(
+				...(this.helpVisible
+					? this.renderHelpPreview(width, previewHeight)
+					: this.renderPreview(width, previewHeight)),
+			);
+		}
 		while (output.length < height) output.push("");
 		if (output.length > height) output.length = height;
 		return output;
@@ -890,28 +963,6 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 			};
 			const getRenderHeight = (): number => getAnycopyRenderHeight(tui.terminal?.rows ?? 40);
 			const helpRows = buildKeyHelpRows(keybindings, keys);
-			const openKeyHelp = (): void => {
-				const terminalWidth = tui.terminal?.columns ?? 120;
-				const preferredWidth = getKeyHelpPreferredWidth(helpRows, visibleWidth);
-				const helpWidth = Math.min(preferredWidth, Math.max(32, terminalWidth - 4));
-				void ctx.ui.custom<void>(
-					(helpTui, helpTheme, _helpKeybindings, closeHelp) => new AnycopyKeyHelp(
-						helpTheme,
-						helpRows,
-						keys.help,
-						() => Math.max(8, Math.floor((helpTui.terminal?.rows ?? 40) * 0.8)),
-						() => helpTui.requestRender(),
-						closeHelp,
-					),
-					{
-						overlay: true,
-						overlayOptions: { anchor: "center", width: helpWidth, maxHeight: "80%", margin: 1 },
-						onHandle: (handle) => handle.focus(),
-					},
-				).catch((error: unknown) => {
-					ctx.ui.notify(error instanceof Error ? error.message : "Failed to open anycopy key help", "error");
-				});
-			};
 			const treeTermHeight = getAnycopyTreeHeight(getRenderHeight());
 			const nodeById = buildNodeMap(initialTree);
 			const validNodeIds = new Set(nodeById.keys());
@@ -1008,7 +1059,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				nodeById,
 				keys,
 				layoutRatios,
-				openKeyHelp,
+				helpRows,
 				persistFoldState ? handleExplicitFoldMutation : null,
 				getRenderHeight,
 				() => tui.requestRender(),

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -7,11 +7,14 @@
  *   Shift+A   - select/unselect focused node for copy
  *   Shift+C   - copy selected nodes (or focused node if none selected)
  *   Shift+X   - clear selection
+ *   Shift+R   - start/finish inclusive range selection
+ *   Tab       - toggle tree-focused and preview-focused layouts
  *   Shift+L   - label node
  *   Shift+T   - toggle label timestamps for labeled nodes
  *   Shift+Ctrl+T - toggle entry-created timestamps for visible tree rows
  *   Shift+↑/↓ - scroll preview
  *   Shift+PageUp/PageDown - page preview
+ *   ?         - show effective native tree and anycopy actions
  *   Esc       - close
  */
 
@@ -39,13 +42,18 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 import { createAnycopyEnterNavigationLauncher, runAnycopyEnterNavigation } from "./enter-navigation.ts";
+import { AnycopyKeyHelp } from "./key-help.ts";
+import { formatConfiguredKey, getKeyHelpPreferredWidth, type KeyHelpRow } from "./key-help-data.ts";
+import { applyInclusiveRangeSelection, togglePaneFocus, type PaneFocus } from "./interaction-state.ts";
 import { getPreviewPageStep, getPreviewWindow } from "./preview-window.ts";
 import { formatCompactTimestamp, getEntryTimestampMs } from "./timestamps.ts";
+import { formatToolCallResultForClipboard, getToolName, resolveToolCallFromParents } from "./tool-call-copy.ts";
 import { buildNodeOrder } from "./tree-order.ts";
 import {
 	getAnycopyRenderHeight,
 	getAnycopyTreeHeight,
 	getAnycopyTreeVisibleLines,
+	type PaneLayoutRatios,
 } from "./viewport-layout.ts";
 import {
 	ANYCOPY_FOLD_STATE_CUSTOM_TYPE,
@@ -85,18 +93,26 @@ type anycopyKeyConfig = {
 	scrollUp: string;
 	pageDown: string;
 	pageUp: string;
+	togglePaneFocus: string;
+	toggleRangeSelection: string;
+	help: string;
 };
 
 type TreeFilterMode = "default" | "no-tools" | "user-only" | "labeled-only" | "all";
 
 type anycopyConfig = {
 	keys?: Partial<anycopyKeyConfig>;
+	layout?: {
+		treeFocusTreeRatio?: number;
+		previewFocusTreeRatio?: number;
+	};
 	treeFilterMode?: TreeFilterMode;
 	persistFoldState?: boolean;
 };
 
 type anycopyRuntimeConfig = {
 	keys: anycopyKeyConfig;
+	layoutRatios: PaneLayoutRatios;
 	treeFilterMode: TreeFilterMode;
 	persistFoldState: boolean;
 };
@@ -117,8 +133,12 @@ const DEFAULT_KEYS: anycopyKeyConfig = {
 	scrollUp: "shift+up",
 	pageDown: "shift+pagedown",
 	pageUp: "shift+pageup",
+	togglePaneFocus: "tab",
+	toggleRangeSelection: "shift+r",
+	help: "?",
 };
 
+const DEFAULT_LAYOUT_RATIOS: PaneLayoutRatios = { tree: 0.85, preview: 0.15 };
 const DEFAULT_TREE_FILTER_MODE: TreeFilterMode = "default";
 const DEFAULT_PERSIST_FOLD_STATE = true;
 
@@ -152,6 +172,7 @@ const loadConfig = (): anycopyRuntimeConfig => {
 	if (!parsed) {
 		return {
 			keys: { ...DEFAULT_KEYS },
+			layoutRatios: { ...DEFAULT_LAYOUT_RATIOS },
 			treeFilterMode: DEFAULT_TREE_FILTER_MODE,
 			persistFoldState: DEFAULT_PERSIST_FOLD_STATE,
 		};
@@ -172,23 +193,14 @@ const loadConfig = (): anycopyRuntimeConfig => {
 			: DEFAULT_TREE_FILTER_MODE;
 	const persistFoldState =
 		typeof parsed.persistFoldState === "boolean" ? parsed.persistFoldState : DEFAULT_PERSIST_FOLD_STATE;
+	const normalizeRatio = (value: unknown, fallback: number): number =>
+		typeof value === "number" && Number.isFinite(value) && value > 0 && value < 1 ? value : fallback;
+	const layoutRatios: PaneLayoutRatios = {
+		tree: normalizeRatio(parsed.layout?.treeFocusTreeRatio, DEFAULT_LAYOUT_RATIOS.tree),
+		preview: normalizeRatio(parsed.layout?.previewFocusTreeRatio, DEFAULT_LAYOUT_RATIOS.preview),
+	};
 
-	return { keys, treeFilterMode, persistFoldState };
-};
-
-const formatKeyHint = (key: string): string => {
-	const normalized = key.trim().toLowerCase();
-	if (normalized === "space") return "Space";
-	const parts = normalized.split("+");
-	return parts
-		.map((part) => {
-			if (part === "shift") return "Shift";
-			if (part === "ctrl") return "Ctrl";
-			if (part === "alt") return "Alt";
-			if (part.length === 1) return part.toUpperCase();
-			return part;
-		})
-		.join("+");
+	return { keys, layoutRatios, treeFilterMode, persistFoldState };
 };
 
 const pluralizeNode = (count: number): string => (count === 1 ? "node" : "nodes");
@@ -196,6 +208,7 @@ const pluralizeNode = (count: number): string => (count === 1 ? "node" : "nodes"
 const MAX_PREVIEW_CHARS = 7000;
 const MAX_PREVIEW_LINES = 200;
 const FLASH_DURATION_MS = 2000;
+const TREE_SELECTOR_PROBE_ROWS = 1;
 
 const getTextContent = (content: unknown): string => {
 	if (typeof content === "string") return content;
@@ -278,64 +291,16 @@ const getEntryContent = (entry: SessionEntry): string => {
 
 const replaceTabs = (text: string): string => text.replace(/\t/g, "   ");
 
-const MAX_PARENT_TRAVERSAL_DEPTH = 30;
-
-const getToolCallId = (entry: SessionEntry): string | null => {
-	if (entry.type !== "message") return null;
-	const msg = entry.message as { role?: string; toolCallId?: unknown };
-	if (msg.role !== "toolResult") return null;
-	return typeof msg.toolCallId === "string" ? msg.toolCallId : null;
-};
-
-const getToolName = (entry: SessionEntry): string | null => {
-	if (entry.type !== "message") return null;
-	const msg = entry.message as { role?: string; toolName?: unknown };
-	if (msg.role !== "toolResult") return null;
-	return typeof msg.toolName === "string" ? msg.toolName : null;
-};
-
-const resolveToolCallArgsFromParents = (
-	entry: SessionEntry,
-	nodeById: Map<string, SessionTreeNode>,
-): Record<string, unknown> | null => {
-	const toolCallId = getToolCallId(entry);
-	if (!toolCallId) return null;
-
-	let parentId = entry.parentId;
-	for (let depth = 0; depth < MAX_PARENT_TRAVERSAL_DEPTH && parentId; depth += 1) {
-		const parentNode = nodeById.get(parentId);
-		if (!parentNode) return null;
-
-		const parentEntry = parentNode.entry;
-		if (parentEntry.type === "message") {
-			const parentMsg = parentEntry.message as { role?: string; content?: unknown };
-			if (parentMsg.role === "assistant" && Array.isArray(parentMsg.content)) {
-				const toolCall = parentMsg.content.find(
-					(c: any) => c && c.type === "toolCall" && c.id === toolCallId,
-				) as { arguments?: unknown } | undefined;
-
-				if (toolCall && typeof toolCall.arguments === "object" && toolCall.arguments !== null) {
-					return toolCall.arguments as Record<string, unknown>;
-				}
-			}
-		}
-
-		parentId = parentEntry.parentId;
-	}
-
-	return null;
-};
-
 const resolveReadToolLanguageFromParents = (
 	entry: SessionEntry,
 	nodeById: Map<string, SessionTreeNode>,
 ): string | undefined => {
 	if (getToolName(entry) !== "read") return undefined;
 
-	const args = resolveToolCallArgsFromParents(entry, nodeById);
+	const args = resolveToolCallFromParents(entry, nodeById)?.arguments;
 	if (!args) return undefined;
 
-	const rawPath = args["file_path"] ?? args["path"];
+	const rawPath = args.file_path ?? args.path;
 	if (typeof rawPath !== "string" || !rawPath.trim()) return undefined;
 	return getLanguageFromPath(rawPath);
 };
@@ -388,25 +353,67 @@ const getTreeListInternals = (treeList: anycopyTreeList): anycopyTreeListInterna
 	return treeList as unknown as anycopyTreeListInternals;
 };
 
+type EffectiveKeybindings = ReturnType<typeof getKeybindings>;
+type EffectiveKeybindingId = Parameters<EffectiveKeybindings["getKeys"]>[0];
+
+const getEffectiveKeys = (keybindings: EffectiveKeybindings, ...ids: string[]): string[] =>
+	[...new Set(ids.flatMap((id) => keybindings.getKeys(id as EffectiveKeybindingId).map(String)))];
+
+const buildKeyHelpRows = (
+	keybindings: EffectiveKeybindings,
+	keys: anycopyKeyConfig,
+): KeyHelpRow[] => [
+	{ keys: getEffectiveKeys(keybindings, "tui.select.up"), label: "move up" },
+	{ keys: getEffectiveKeys(keybindings, "tui.select.down"), label: "move down" },
+	{ keys: getEffectiveKeys(keybindings, "tui.editor.cursorLeft", "tui.select.pageUp"), label: "page tree up" },
+	{ keys: getEffectiveKeys(keybindings, "tui.editor.cursorRight", "tui.select.pageDown"), label: "page tree down" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.foldOrUp"), label: "fold branch or jump up" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.unfoldOrDown"), label: "unfold branch or jump down" },
+	{ keys: getEffectiveKeys(keybindings, "tui.select.confirm"), label: "navigate to focused node" },
+	{ keys: getEffectiveKeys(keybindings, "tui.select.cancel"), label: "clear search or close" },
+	{ keys: getEffectiveKeys(keybindings, "tui.editor.deleteCharBackward"), label: "delete search character" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.editLabel"), label: "edit label" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.default"), label: "use default filter" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.noTools"), label: "toggle no-tools filter" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.userOnly"), label: "toggle user-only filter" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.labeledOnly"), label: "toggle labeled-only filter" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.all"), label: "toggle all-entries filter" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.cycleForward"), label: "cycle filter forward" },
+	{ keys: getEffectiveKeys(keybindings, "app.tree.filter.cycleBackward"), label: "cycle filter backward" },
+	{ keys: ["printable text"], label: "search visible nodes" },
+	{ keys: [keys.toggleSelect], label: "toggle focused node selection" },
+	{ keys: [keys.toggleRangeSelection], label: "start or finish range selection" },
+	{ keys: [keys.copy], label: "copy focused or selected nodes" },
+	{ keys: [keys.clear], label: "clear selection" },
+	{ keys: [keys.togglePaneFocus], label: "toggle tree or preview focus" },
+	{ keys: [keys.scrollUp, keys.scrollDown], label: "scroll preview" },
+	{ keys: [keys.pageUp, keys.pageDown], label: "page preview" },
+	{ keys: [keys.toggleLabelTimestamps], label: "toggle label timestamps" },
+	{ keys: [keys.toggleEntryTimestamps], label: "toggle entry timestamps" },
+	{ keys: [keys.help], label: "show or close this help" },
+];
+
 /** Clipboard text omits role prefix for a single node and includes it for multi-node copies
  * The preview pane is truncated for performance, while the clipboard copy is not
  */
-const buildClipboardText = (nodes: SessionTreeNode[]): string => {
-	if (nodes.length === 1) {
-		return getEntryContent(nodes[0]!.entry);
-	}
-
-	return nodes
-		.map((node) => {
-			const label = getEntryRoleLabel(node.entry);
-			const content = getEntryContent(node.entry);
-			return `${label}:\n\n${content}`;
-		})
-		.join("\n\n---\n\n");
+const buildClipboardText = (
+	nodes: SessionTreeNode[],
+	nodeById: ReadonlyMap<string, SessionTreeNode>,
+): string => {
+	const formatNode = (node: SessionTreeNode, includeRole: boolean): string => {
+		const toolPair = formatToolCallResultForClipboard(node.entry, nodeById);
+		if (toolPair) return toolPair;
+		const content = getEntryContent(node.entry);
+		return includeRole ? `${getEntryRoleLabel(node.entry)}:\n\n${content}` : content;
+	};
+	if (nodes.length === 1) return formatNode(nodes[0]!, false);
+	return nodes.map((node) => formatNode(node, true)).join("\n\n---\n\n");
 };
 
 class anycopyOverlay implements Focusable {
 	private selectedNodeIds = new Set<string>();
+	private paneFocus: PaneFocus = "tree";
+	private rangeSelection: { anchorId: string; baselineIds: Set<string> } | null = null;
 	private showEntryTimestamps = false;
 	private flashMessage: string | null = null;
 	private flashTimer: ReturnType<typeof setTimeout> | null = null;
@@ -425,6 +432,8 @@ class anycopyOverlay implements Focusable {
 		private getTree: () => SessionTreeNode[],
 		private nodeById: Map<string, SessionTreeNode>,
 		private keys: anycopyKeyConfig,
+		private layoutRatios: PaneLayoutRatios,
+		private openHelp: () => void,
 		private onExplicitFoldMutation: ((
 			beforeTransientFoldedNodeIds: string[],
 			afterTransientFoldedNodeIds: string[],
@@ -453,15 +462,32 @@ class anycopyOverlay implements Focusable {
 			return;
 		}
 
+		if (matchesKey(data, this.keys.help as MatchesKeyId)) {
+			this.openHelp();
+			return;
+		}
+		if (matchesKey(data, this.keys.togglePaneFocus as MatchesKeyId)) {
+			this.paneFocus = togglePaneFocus(this.paneFocus);
+			this.lastPreviewHeight = 0;
+			this.flash(this.paneFocus === "tree" ? "Tree-focused layout" : "Preview-focused layout");
+			return;
+		}
+		if (matchesKey(data, this.keys.toggleRangeSelection as MatchesKeyId)) {
+			this.toggleRangeSelection();
+			return;
+		}
 		if (matchesKey(data, this.keys.toggleSelect as MatchesKeyId)) {
+			this.rangeSelection = null;
 			this.toggleSelectedFocusedNode();
 			return;
 		}
 		if (matchesKey(data, this.keys.copy as MatchesKeyId)) {
+			this.rangeSelection = null;
 			this.copySelectedOrFocusedNode();
 			return;
 		}
 		if (matchesKey(data, this.keys.clear as MatchesKeyId)) {
+			this.rangeSelection = null;
 			this.clearSelection();
 			return;
 		}
@@ -505,12 +531,31 @@ class anycopyOverlay implements Focusable {
 			return;
 		}
 
+		const beforeVisibleIds = this.getVisibleFilteredNodeIds();
+		const beforeFocusedId = this.getFocusedNode()?.entry.id;
 		const shouldTrackExplicitFoldMutation =
 			this.onExplicitFoldMutation !== null &&
 			(keybindings.matches(data, "app.tree.foldOrUp") || keybindings.matches(data, "app.tree.unfoldOrDown"));
 		const beforeTransientFoldedNodeIds = shouldTrackExplicitFoldMutation ? getSelectorFoldedNodeIds(this.selector) : null;
 
 		this.selector.handleInput(data);
+
+		const afterVisibleIds = this.getVisibleFilteredNodeIds();
+		const visibleRowsChanged = beforeVisibleIds.length !== afterVisibleIds.length ||
+			beforeVisibleIds.some((id, index) => id !== afterVisibleIds[index]);
+		if (visibleRowsChanged) {
+			this.rangeSelection = null;
+		} else if (this.rangeSelection) {
+			const focusedId = this.getFocusedNode()?.entry.id;
+			if (focusedId && focusedId !== beforeFocusedId) {
+				this.selectedNodeIds = applyInclusiveRangeSelection(
+					this.rangeSelection.baselineIds,
+					afterVisibleIds,
+					this.rangeSelection.anchorId,
+					focusedId,
+				);
+			}
+		}
 
 		if (beforeTransientFoldedNodeIds) {
 			this.onExplicitFoldMutation?.(beforeTransientFoldedNodeIds, getSelectorFoldedNodeIds(this.selector));
@@ -533,6 +578,32 @@ class anycopyOverlay implements Focusable {
 
 	private getFocusedNode(): SessionTreeNode | undefined {
 		return this.selector.getTreeList().getSelectedNode();
+	}
+
+	private getVisibleFilteredNodeIds(): string[] {
+		return this.getTreeListInternals().filteredNodes
+			.map(({ node }) => node.entry.id)
+			.filter((id): id is string => typeof id === "string");
+	}
+
+	private toggleRangeSelection(): void {
+		if (this.rangeSelection) {
+			this.rangeSelection = null;
+			this.flash(`Range selected (${this.selectedNodeIds.size} ${pluralizeNode(this.selectedNodeIds.size)})`);
+			return;
+		}
+		const focused = this.getFocusedNode();
+		if (!focused) return;
+		const anchorId = focused.entry.id;
+		const baselineIds = new Set(this.selectedNodeIds);
+		this.rangeSelection = { anchorId, baselineIds };
+		this.selectedNodeIds = applyInclusiveRangeSelection(
+			baselineIds,
+			this.getVisibleFilteredNodeIds(),
+			anchorId,
+			anchorId,
+		);
+		this.flash("Range toggle active, move to extend");
 	}
 
 	private flash(message: string): void {
@@ -602,7 +673,7 @@ class anycopyOverlay implements Focusable {
 				return oa - ob;
 			});
 
-		copyToClipboard(buildClipboardText(nodes));
+		copyToClipboard(buildClipboardText(nodes, nodeById));
 		this.flash(`Copied ${nodes.length} ${pluralizeNode(nodes.length)} to clipboard`);
 	}
 
@@ -624,19 +695,17 @@ class anycopyOverlay implements Focusable {
 			);
 		}
 
-		const compactKey = (key: string): string =>
-			formatKeyHint(key)
-				.replace(/^Shift(?=\+)/i, "S")
-				.replace(/\+Ctrl(?=\+|$)/gi, "+C")
-				.replace(/\+Alt(?=\+|$)/gi, "+A");
+		const key = formatConfiguredKey;
 		const hint =
-			`  ${compactKey(this.keys.scrollUp)}/${compactKey(this.keys.scrollDown)}: scroll` +
-			` · ${compactKey(this.keys.pageUp)}/${compactKey(this.keys.pageDown)}: page` +
+			`  ${key(this.keys.scrollUp)}/${key(this.keys.scrollDown)}: scroll preview` +
+			` · ${key(this.keys.pageUp)}/${key(this.keys.pageDown)}: page preview` +
 			` · Enter: navigate` +
-			` · ${compactKey(this.keys.toggleSelect)}: select` +
-			` · ${compactKey(this.keys.copy)}: copy` +
-			` · ${compactKey(this.keys.clear)}: clear` +
-			` · ${compactKey(this.keys.toggleEntryTimestamps)}: entry time`;
+			` · ${key(this.keys.toggleRangeSelection)}: range` +
+			` · ${key(this.keys.toggleSelect)}: select` +
+			` · ${key(this.keys.copy)}: copy` +
+			` · ${key(this.keys.clear)}: clear` +
+			` · ${key(this.keys.togglePaneFocus)}: layout` +
+			` · ${key(this.keys.help)}: help`;
 		lines.push(truncateToWidth(this.theme.fg("dim", hint), width));
 
 		return lines;
@@ -659,7 +728,17 @@ class anycopyOverlay implements Focusable {
 
 		const content = getEntryContent(focused.entry);
 		const clipped = clipTextForPreview(content);
-		const rendered = renderPreviewBodyLines(clipped, focused.entry, width, this.theme, this.nodeById);
+		const resultLines = renderPreviewBodyLines(clipped, focused.entry, width, this.theme, this.nodeById);
+		const invocation = resolveToolCallFromParents(focused.entry, this.nodeById);
+		const rendered = invocation
+			? [
+				truncateToWidth(`${this.theme.fg("muted", "Tool")}  ${this.theme.fg("accent", invocation.name)}`, width),
+				truncateToWidth(this.theme.fg("muted", "Arguments"), width),
+				...highlightCode(JSON.stringify(invocation.arguments, null, 2), "json").map((line) => truncateToWidth(line, width)),
+				this.theme.fg("dim", "─".repeat(Math.max(1, width))),
+				...resultLines,
+			]
+			: resultLines;
 		const preview = {
 			entryId,
 			width,
@@ -719,14 +798,9 @@ class anycopyOverlay implements Focusable {
 		return lines;
 	}
 
-	render(width: number): string[] {
-		const height = this.getRenderHeight();
-		const output: string[] = [];
-
-		this.getTreeListInternals().maxVisibleLines = getAnycopyTreeVisibleLines(height);
+	private renderSelector(width: number, visibleRows: number): string[] {
+		this.getTreeListInternals().maxVisibleLines = Math.max(1, visibleRows);
 		const selectorLines = this.selector.render(width);
-
-		// Remove the selector's spacer after the search prompt and before its bottom border
 		const searchLineIndex = selectorLines.findIndex((line) => line.includes("Type to search"));
 		const listStartIndex = searchLineIndex >= 0 ? searchLineIndex + 2 : -1;
 		if (listStartIndex >= 0 && visibleWidth(selectorLines[listStartIndex] ?? "") === 0) {
@@ -738,15 +812,24 @@ class anycopyOverlay implements Focusable {
 		while (selectorLines.length > 0 && visibleWidth(selectorLines.at(-1) ?? "") === 0) {
 			selectorLines.pop();
 		}
+		return selectorLines;
+	}
 
-		output.push(...selectorLines);
-		output.push(...this.renderStatusBar(width));
+	render(width: number): string[] {
+		const height = this.getRenderHeight();
+		const output: string[] = [];
+		const statusLines = this.renderStatusBar(width);
+		const probeLines = this.renderSelector(width, TREE_SELECTOR_PROBE_ROWS);
+		const selectorChromeRows = Math.max(0, probeLines.length - TREE_SELECTOR_PROBE_ROWS);
+		const availablePaneRows = Math.max(1, height - selectorChromeRows - statusLines.length);
+		const treeVisibleRows = getAnycopyTreeVisibleLines(availablePaneRows, this.paneFocus, this.layoutRatios);
+		const selectorLines = treeVisibleRows === TREE_SELECTOR_PROBE_ROWS
+			? probeLines
+			: this.renderSelector(width, treeVisibleRows);
 
+		output.push(...selectorLines, ...statusLines);
 		const previewHeight = Math.max(0, height - output.length);
-		if (previewHeight > 0) {
-			output.push(...this.renderPreview(width, previewHeight));
-		}
-
+		if (previewHeight > 0) output.push(...this.renderPreview(width, previewHeight));
 		while (output.length < height) output.push("");
 		if (output.length > height) output.length = height;
 		return output;
@@ -767,6 +850,7 @@ class anycopyOverlay implements Focusable {
 export default function anycopyExtension(pi: ExtensionAPI) {
 	const config = loadConfig();
 	const keys = config.keys;
+	const layoutRatios = config.layoutRatios;
 	const treeFilterMode = config.treeFilterMode;
 	const persistFoldState = config.persistFoldState;
 
@@ -787,7 +871,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 		const skipSummaryPrompt = loadBranchSummarySkipPrompt(ctx.cwd);
 		let overlayHandle: { focus(): void; unfocus(): void } | undefined;
 
-		await ctx.ui.custom<void>((tui, theme, _kb, done) => {
+		await ctx.ui.custom<void>((tui, theme, keybindings, done) => {
 			let closed = false;
 			const closeOverlay = (): void => {
 				if (closed) return;
@@ -796,6 +880,29 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				done();
 			};
 			const getRenderHeight = (): number => getAnycopyRenderHeight(tui.terminal?.rows ?? 40);
+			const helpRows = buildKeyHelpRows(keybindings, keys);
+			const openKeyHelp = (): void => {
+				const terminalWidth = tui.terminal?.columns ?? 120;
+				const preferredWidth = getKeyHelpPreferredWidth(helpRows, visibleWidth);
+				const helpWidth = Math.min(preferredWidth, Math.max(32, terminalWidth - 4));
+				void ctx.ui.custom<void>(
+					(helpTui, helpTheme, _helpKeybindings, closeHelp) => new AnycopyKeyHelp(
+						helpTheme,
+						helpRows,
+						keys.help,
+						() => Math.max(8, Math.floor((helpTui.terminal?.rows ?? 40) * 0.8)),
+						() => helpTui.requestRender(),
+						closeHelp,
+					),
+					{
+						overlay: true,
+						overlayOptions: { anchor: "center", width: helpWidth, maxHeight: "80%", margin: 1 },
+						onHandle: (handle) => handle.focus(),
+					},
+				).catch((error: unknown) => {
+					ctx.ui.notify(error instanceof Error ? error.message : "Failed to open anycopy key help", "error");
+				});
+			};
 			const treeTermHeight = getAnycopyTreeHeight(getRenderHeight());
 			const nodeById = buildNodeMap(initialTree);
 			const validNodeIds = new Set(nodeById.keys());
@@ -891,6 +998,8 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				getTree,
 				nodeById,
 				keys,
+				layoutRatios,
+				openKeyHelp,
 				persistFoldState ? handleExplicitFoldMutation : null,
 				getRenderHeight,
 				() => tui.requestRender(),

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -21,6 +21,7 @@
 import type {
 	ExtensionAPI,
 	ExtensionCommandContext,
+	ExtensionContext,
 	KeybindingsManager,
 	SessionEntry,
 } from "@earendil-works/pi-coding-agent";
@@ -46,12 +47,13 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
+import { formatCustomEntryContent, formatCustomEntryPreview } from "./custom-entry.ts";
 import { createAnycopyEnterNavigationLauncher, runAnycopyEnterNavigation } from "./enter-navigation.ts";
 import { getKeyHelpWindow, renderKeyHelpLines } from "./key-help.ts";
 import { buildKeyHelpRows, formatConfiguredKey, type KeyHelpRow } from "./key-help-data.ts";
 import { applyInclusiveRangeSelection, togglePaneFocus, type PaneFocus } from "./interaction-state.ts";
 import { getPreviewPageStep, getPreviewWindow } from "./preview-window.ts";
-import { renderStatusHints } from "./status-hints.ts";
+import { buildStatusTextLines, renderStatusHints, type HintMode } from "./status-hints.ts";
 import { formatCompactTimestamp, getEntryTimestampMs } from "./timestamps.ts";
 import {
 	formatJsonForDisplay,
@@ -114,6 +116,10 @@ type TreeFilterMode = "default" | "no-tools" | "user-only" | "labeled-only" | "a
 
 type anycopyConfig = {
 	keys?: Partial<anycopyKeyConfig>;
+	shortcut?: string | null;
+	hints?: {
+		mode?: HintMode;
+	};
 	layout?: {
 		treeFocusTreeRatio?: number;
 		previewFocusTreeRatio?: number;
@@ -124,6 +130,8 @@ type anycopyConfig = {
 
 type anycopyRuntimeConfig = {
 	keys: anycopyKeyConfig;
+	shortcut: string | null;
+	hintMode: HintMode;
 	layoutRatios: PaneLayoutRatios;
 	treeFilterMode: TreeFilterMode;
 	persistFoldState: boolean;
@@ -153,6 +161,8 @@ const DEFAULT_KEYS: anycopyKeyConfig = {
 const DEFAULT_LAYOUT_RATIOS: PaneLayoutRatios = { tree: 0.85, preview: 0.15 };
 const DEFAULT_TREE_FILTER_MODE: TreeFilterMode = "default";
 const DEFAULT_PERSIST_FOLD_STATE = true;
+const DEFAULT_SHORTCUT = null;
+const DEFAULT_HINT_MODE: HintMode = "full";
 
 const getExtensionDir = (): string => {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -184,6 +194,8 @@ const loadConfig = (): anycopyRuntimeConfig => {
 	if (!parsed) {
 		return {
 			keys: { ...DEFAULT_KEYS },
+			shortcut: DEFAULT_SHORTCUT,
+			hintMode: DEFAULT_HINT_MODE,
 			layoutRatios: { ...DEFAULT_LAYOUT_RATIOS },
 			treeFilterMode: DEFAULT_TREE_FILTER_MODE,
 			persistFoldState: DEFAULT_PERSIST_FOLD_STATE,
@@ -205,6 +217,8 @@ const loadConfig = (): anycopyRuntimeConfig => {
 			: DEFAULT_TREE_FILTER_MODE;
 	const persistFoldState =
 		typeof parsed.persistFoldState === "boolean" ? parsed.persistFoldState : DEFAULT_PERSIST_FOLD_STATE;
+	const shortcut = typeof parsed.shortcut === "string" && parsed.shortcut.trim() ? parsed.shortcut.trim() : null;
+	const hintMode: HintMode = parsed.hints?.mode === "compact" ? "compact" : DEFAULT_HINT_MODE;
 	const normalizeRatio = (value: unknown, fallback: number): number =>
 		typeof value === "number" && Number.isFinite(value) && value > 0 && value < 1 ? value : fallback;
 	const layoutRatios: PaneLayoutRatios = {
@@ -212,7 +226,7 @@ const loadConfig = (): anycopyRuntimeConfig => {
 		preview: normalizeRatio(parsed.layout?.previewFocusTreeRatio, DEFAULT_LAYOUT_RATIOS.preview),
 	};
 
-	return { keys, layoutRatios, treeFilterMode, persistFoldState };
+	return { keys, shortcut, hintMode, layoutRatios, treeFilterMode, persistFoldState };
 };
 
 const pluralizeNode = (count: number): string => (count === 1 ? "node" : "nodes");
@@ -287,7 +301,7 @@ const getEntryContent = (entry: SessionEntry): string => {
 		case "branch_summary":
 			return entry.summary;
 		case "custom":
-			return `[custom: ${entry.customType}]`;
+			return formatCustomEntryContent(entry.customType, entry.data);
 		case "label":
 			return `label: ${entry.label ?? "(cleared)"}`;
 		case "model_change":
@@ -300,6 +314,9 @@ const getEntryContent = (entry: SessionEntry): string => {
 			return "";
 	}
 };
+
+const getPreviewEntryContent = (entry: SessionEntry): string =>
+	entry.type === "custom" ? formatCustomEntryPreview(entry.customType, entry.data) : getEntryContent(entry);
 
 const replaceTabs = (text: string): string => text.replace(/\t/g, "   ");
 
@@ -412,6 +429,8 @@ class anycopyOverlay implements Focusable {
 		private layoutRatios: PaneLayoutRatios,
 		private helpRows: readonly KeyHelpRow[],
 		private keybindings: KeybindingsManager,
+		private hintMode: HintMode,
+		private navigationAvailable: boolean,
 		private onExplicitFoldMutation: ((
 			beforeTransientFoldedNodeIds: string[],
 			afterTransientFoldedNodeIds: string[],
@@ -606,7 +625,7 @@ class anycopyOverlay implements Focusable {
 			anchorId,
 			anchorId,
 		);
-		this.flash("Range toggle active, move to extend");
+		this.flash("Range select active, move to extend");
 	}
 
 	private flash(message: string): void {
@@ -685,44 +704,35 @@ class anycopyOverlay implements Focusable {
 	}
 
 	private renderStatusBar(width: number): string[] {
-		const lines: string[] = [];
-
-		// Keep transient/selection status compact; omit the row entirely when idle.
-		if (this.flashMessage) {
-			lines.push(truncateToWidth(this.theme.fg("success", `  ${this.flashMessage}`), width));
-		} else if (this.selectedNodeIds.size > 0) {
-			lines.push(
-				truncateToWidth(
-					this.theme.fg(
-						"accent",
-						`  ${this.selectedNodeIds.size} selected ${pluralizeNode(this.selectedNodeIds.size)}`,
-					),
-					width,
-				),
-			);
-		}
-
 		const key = formatConfiguredKey;
-		lines.push(
-			...renderStatusHints(
-				[
-					`${key(this.keys.scrollUp)}/${key(this.keys.scrollDown)}: scroll preview`,
-					`${key(this.keys.pageUp)}/${key(this.keys.pageDown)}: page preview`,
-					"Enter: navigate",
-					`${key(this.keys.toggleRangeSelection)}: range`,
-					`${key(this.keys.toggleSelect)}: select`,
-					`${key(this.keys.copy)}: copy`,
-					`${key(this.keys.clear)}: clear`,
-					`${key(this.keys.togglePaneFocus)}: layout`,
-					`${key(this.keys.help)}: help`,
-				],
-				width,
-				wrapTextWithAnsi,
-				(text) => this.theme.fg("dim", text),
-			),
+		const navigationLabel = this.navigationAvailable ? "navigate" : "open /anycopy to navigate";
+		const status = this.flashMessage
+			?? (this.rangeSelection
+				? `Range selection active, ${this.selectedNodeIds.size} selected ${pluralizeNode(this.selectedNodeIds.size)}`
+				: this.selectedNodeIds.size > 0
+					? `${this.selectedNodeIds.size} selected ${pluralizeNode(this.selectedNodeIds.size)}`
+					: this.hintMode === "compact"
+						? `${key(this.keys.help)}: help · Enter: ${navigationLabel}`
+						: "Ready");
+		const statusRole = this.flashMessage ? "success" : this.selectedNodeIds.size > 0 ? "accent" : "dim";
+		const hintLines = renderStatusHints(
+			[
+				`${key(this.keys.scrollUp)}/${key(this.keys.scrollDown)}: scroll preview`,
+				`${key(this.keys.pageUp)}/${key(this.keys.pageDown)}: page preview`,
+				`Enter: ${navigationLabel}`,
+				`${key(this.keys.toggleRangeSelection)}: range`,
+				`${key(this.keys.toggleSelect)}: select`,
+				`${key(this.keys.copy)}: copy`,
+				`${key(this.keys.clear)}: clear`,
+				`${key(this.keys.togglePaneFocus)}: layout`,
+				`${key(this.keys.help)}: help`,
+			],
+			width,
+			wrapTextWithAnsi,
 		);
-
-		return lines;
+		return buildStatusTextLines(this.hintMode, status, hintLines).map((line, index) =>
+			truncateToWidth(this.theme.fg(index === 0 ? statusRole : "dim", line), width),
+		);
 	}
 
 	private renderPreviewDivider(width: number, message?: string): string {
@@ -740,7 +750,7 @@ class anycopyOverlay implements Focusable {
 			return this.previewCache;
 		}
 
-		const content = getEntryContent(focused.entry);
+		const content = getPreviewEntryContent(focused.entry);
 		const clipped = clipTextForPreview(content);
 		const resultLines = renderPreviewBodyLines(clipped, focused.entry, width, this.theme, this.nodeById);
 		const invocation = resolveToolCallFromParents(focused.entry, this.nodeById);
@@ -916,15 +926,20 @@ class anycopyOverlay implements Focusable {
 	}
 }
 
+const canNavigateTree = (ctx: ExtensionContext): ctx is ExtensionCommandContext =>
+	typeof (ctx as { navigateTree?: unknown }).navigateTree === "function";
+
 export default function anycopyExtension(pi: ExtensionAPI) {
 	const config = loadConfig();
 	const keys = config.keys;
+	const shortcut = config.shortcut;
+	const hintMode = config.hintMode;
 	const layoutRatios = config.layoutRatios;
 	const treeFilterMode = config.treeFilterMode;
 	const persistFoldState = config.persistFoldState;
 
 	const openAnycopy = async (
-		ctx: ExtensionCommandContext,
+		ctx: ExtensionContext,
 		opts?: { initialSelectedId?: string },
 	) => {
 		if (!ctx.hasUI) return;
@@ -949,9 +964,11 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				done();
 			};
 			const getRenderHeight = (): number => getAnycopyRenderHeight(tui.terminal?.rows ?? 40);
+			const navigationAvailable = canNavigateTree(ctx);
 			const helpRows = buildKeyHelpRows(
 				(id) => keybindings.getKeys(id as EffectiveKeybindingId).map(String),
 				keys,
+				navigationAvailable,
 			);
 			const treeTermHeight = getAnycopyTreeHeight(getRenderHeight());
 			const nodeById = buildNodeMap(initialTree);
@@ -963,26 +980,28 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 			let lastPersistedFoldedNodeIds = durableFoldedNodeIds;
 			const currentLeafIdForNoop = currentLeafId;
 
-			const startEnterNavigation = createAnycopyEnterNavigationLauncher(async (entryId) =>
-				runAnycopyEnterNavigation({
-					entryId,
-					currentLeafIdForNoop,
-					skipSummaryPrompt,
-					close: closeOverlay,
-					reopen: (reopenOpts) => {
-						void openAnycopy(ctx, reopenOpts);
-					},
-					navigateTree: async (targetId, options) => ctx.navigateTree(targetId, options),
-					ui: {
-						select: async (title, options) =>
-							(await ctx.ui.select(title, options)) as (typeof options)[number] | undefined,
-						editor: (title) => ctx.ui.editor(title),
-						setStatus: (source, message) => ctx.ui.setStatus(source, message),
-						setWorkingMessage: (message) => ctx.ui.setWorkingMessage(message),
-						notify: (message, level) => ctx.ui.notify(message, level),
-					},
-				}),
-			);
+			const startEnterNavigation = navigationAvailable
+				? createAnycopyEnterNavigationLauncher(async (entryId) =>
+					runAnycopyEnterNavigation({
+						entryId,
+						currentLeafIdForNoop,
+						skipSummaryPrompt,
+						close: closeOverlay,
+						reopen: (reopenOpts) => {
+							void openAnycopy(ctx, reopenOpts);
+						},
+						navigateTree: async (targetId, options) => ctx.navigateTree(targetId, options),
+						ui: {
+							select: async (title, options) =>
+								(await ctx.ui.select(title, options)) as (typeof options)[number] | undefined,
+							editor: (title) => ctx.ui.editor(title),
+							setStatus: (source, message) => ctx.ui.setStatus(source, message),
+							setWorkingMessage: (message) => ctx.ui.setWorkingMessage(message),
+							notify: (message, level) => ctx.ui.notify(message, level),
+						},
+					}),
+				)
+				: () => ctx.ui.notify("Navigation requires opening /anycopy as a command", "warning");
 
 			const selector = new TreeSelectorComponent(
 				initialTree,
@@ -1051,6 +1070,8 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				layoutRatios,
 				helpRows,
 				keybindings,
+				hintMode,
+				navigationAvailable,
 				persistFoldState ? handleExplicitFoldMutation : null,
 				getRenderHeight,
 				() => tui.requestRender(),
@@ -1129,4 +1150,14 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 			await openAnycopy(ctx);
 		},
 	});
+
+	if (shortcut) {
+		pi.registerShortcut(shortcut as Parameters<ExtensionAPI["registerShortcut"]>[0], {
+			description: "Open /anycopy in copy-only mode",
+			handler: async (ctx: ExtensionContext) => {
+				if (!ctx.hasUI) return;
+				await openAnycopy(ctx);
+			},
+		});
+	}
 }

--- a/extensions/anycopy/index.ts
+++ b/extensions/anycopy/index.ts
@@ -670,6 +670,10 @@ class anycopyOverlay implements Focusable {
 		return this.showEntryTimestamps;
 	}
 
+	showNavigationUnavailable(): void {
+		this.flash("Navigation requires opening /anycopy as a command");
+	}
+
 	copySelectedOrFocusedNode(): void {
 		const focused = this.getFocusedNode();
 		const ids =
@@ -720,8 +724,8 @@ class anycopyOverlay implements Focusable {
 				`${key(this.keys.scrollUp)}/${key(this.keys.scrollDown)}: scroll preview`,
 				`${key(this.keys.pageUp)}/${key(this.keys.pageDown)}: page preview`,
 				`Enter: ${navigationLabel}`,
-				`${key(this.keys.toggleRangeSelection)}: range`,
-				`${key(this.keys.toggleSelect)}: select`,
+				`${key(this.keys.toggleRangeSelection)}: select range`,
+				`${key(this.keys.toggleSelect)}: (de)select node`,
 				`${key(this.keys.copy)}: copy`,
 				`${key(this.keys.clear)}: clear`,
 				`${key(this.keys.togglePaneFocus)}: layout`,
@@ -889,6 +893,8 @@ class anycopyOverlay implements Focusable {
 
 	render(width: number): string[] {
 		const height = this.getRenderHeight();
+		if (this.helpVisible) return this.renderHelpPreview(width, height);
+
 		const output: string[] = [];
 		const statusLines = this.renderStatusBar(width);
 		const probeLines = this.renderSelector(width, TREE_SELECTOR_PROBE_ROWS);
@@ -901,13 +907,7 @@ class anycopyOverlay implements Focusable {
 
 		output.push(...selectorLines, ...statusLines);
 		const previewHeight = Math.max(0, height - output.length);
-		if (previewHeight > 0) {
-			output.push(
-				...(this.helpVisible
-					? this.renderHelpPreview(width, previewHeight)
-					: this.renderPreview(width, previewHeight)),
-			);
-		}
+		if (previewHeight > 0) output.push(...this.renderPreview(width, previewHeight));
 		while (output.length < height) output.push("");
 		if (output.length > height) output.length = height;
 		return output;
@@ -957,6 +957,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 
 		await ctx.ui.custom<void>((tui, theme, keybindings, done) => {
 			let closed = false;
+			let overlay: anycopyOverlay | undefined;
 			const closeOverlay = (): void => {
 				if (closed) return;
 				closed = true;
@@ -1001,7 +1002,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 						},
 					}),
 				)
-				: () => ctx.ui.notify("Navigation requires opening /anycopy as a command", "warning");
+				: () => overlay?.showNavigationUnavailable();
 
 			const selector = new TreeSelectorComponent(
 				initialTree,
@@ -1062,7 +1063,7 @@ export default function anycopyExtension(pi: ExtensionAPI) {
 				persistDurableFoldState(nextDurableFoldedNodeIds);
 			};
 
-			const overlay = new anycopyOverlay(
+			overlay = new anycopyOverlay(
 				selector,
 				getTree,
 				nodeById,

--- a/extensions/anycopy/interaction-state.ts
+++ b/extensions/anycopy/interaction-state.ts
@@ -18,9 +18,7 @@ export const applyInclusiveRangeSelection = (
 	const end = Math.max(anchorIndex, focusedIndex);
 	for (let index = start; index <= end; index += 1) {
 		const id = orderedVisibleIds[index];
-		if (!id) continue;
-		if (baselineIds.has(id)) selected.delete(id);
-		else selected.add(id);
+		if (id) selected.add(id);
 	}
 	return selected;
 };

--- a/extensions/anycopy/interaction-state.ts
+++ b/extensions/anycopy/interaction-state.ts
@@ -1,0 +1,26 @@
+export type PaneFocus = "tree" | "preview";
+
+export const togglePaneFocus = (focus: PaneFocus): PaneFocus =>
+	focus === "tree" ? "preview" : "tree";
+
+export const applyInclusiveRangeSelection = (
+	baselineIds: ReadonlySet<string>,
+	orderedVisibleIds: readonly string[],
+	anchorId: string,
+	focusedId: string,
+): Set<string> => {
+	const selected = new Set(baselineIds);
+	const anchorIndex = orderedVisibleIds.indexOf(anchorId);
+	const focusedIndex = orderedVisibleIds.indexOf(focusedId);
+	if (anchorIndex < 0 || focusedIndex < 0) return selected;
+
+	const start = Math.min(anchorIndex, focusedIndex);
+	const end = Math.max(anchorIndex, focusedIndex);
+	for (let index = start; index <= end; index += 1) {
+		const id = orderedVisibleIds[index];
+		if (!id) continue;
+		if (baselineIds.has(id)) selected.delete(id);
+		else selected.add(id);
+	}
+	return selected;
+};

--- a/extensions/anycopy/key-help-data.ts
+++ b/extensions/anycopy/key-help-data.ts
@@ -30,12 +30,3 @@ export const formatConfiguredKey = (key: string): string => {
 
 export const formatHelpRowKeys = (row: KeyHelpRow): string =>
 	row.keys.map(formatConfiguredKey).join(" / ");
-
-export const getKeyHelpPreferredWidth = (
-	rows: readonly KeyHelpRow[],
-	measureWidth: (text: string) => number = (text) => text.length,
-): number => {
-	const keyWidth = Math.max(3, ...rows.map((row) => measureWidth(formatHelpRowKeys(row))));
-	const actionWidth = Math.max(6, ...rows.map((row) => measureWidth(row.label)));
-	return Math.max(56, keyWidth + actionWidth + 7);
-};

--- a/extensions/anycopy/key-help-data.ts
+++ b/extensions/anycopy/key-help-data.ts
@@ -3,6 +3,21 @@ export type KeyHelpRow = {
 	label: string;
 };
 
+export type AnycopyHelpKeys = {
+	toggleSelect: string;
+	copy: string;
+	clear: string;
+	toggleLabelTimestamps: string;
+	toggleEntryTimestamps: string;
+	scrollDown: string;
+	scrollUp: string;
+	pageDown: string;
+	pageUp: string;
+	togglePaneFocus: string;
+	toggleRangeSelection: string;
+	help: string;
+};
+
 export const formatConfiguredKey = (key: string): string => {
 	const normalized = key.trim().toLowerCase();
 	if (normalized === "space") return "Space";
@@ -12,8 +27,11 @@ export const formatConfiguredKey = (key: string): string => {
 		shift: "Shift",
 		ctrl: "Ctrl",
 		alt: "Alt",
+		super: "Super",
 		enter: "Enter",
+		return: "Enter",
 		tab: "Tab",
+		esc: "Esc",
 		up: "Up",
 		down: "Down",
 		left: "Left",
@@ -30,3 +48,42 @@ export const formatConfiguredKey = (key: string): string => {
 
 export const formatHelpRowKeys = (row: KeyHelpRow): string =>
 	row.keys.map(formatConfiguredKey).join(" / ");
+
+export const buildKeyHelpRows = (
+	getKeys: (id: string) => readonly string[],
+	keys: AnycopyHelpKeys,
+): KeyHelpRow[] => {
+	const effectiveKeys = (...ids: string[]): string[] =>
+		[...new Set(ids.flatMap((id) => getKeys(id)).filter((key) => key.trim().length > 0))];
+
+	return [
+		{ keys: effectiveKeys("tui.select.up"), label: "move up" },
+		{ keys: effectiveKeys("tui.select.down"), label: "move down" },
+		{ keys: effectiveKeys("tui.editor.cursorLeft", "tui.select.pageUp"), label: "page tree up" },
+		{ keys: effectiveKeys("tui.editor.cursorRight", "tui.select.pageDown"), label: "page tree down" },
+		{ keys: effectiveKeys("app.tree.foldOrUp"), label: "fold branch or jump up" },
+		{ keys: effectiveKeys("app.tree.unfoldOrDown"), label: "unfold branch or jump down" },
+		{ keys: effectiveKeys("tui.select.confirm"), label: "navigate to focused node" },
+		{ keys: effectiveKeys("tui.select.cancel"), label: "clear search or close" },
+		{ keys: effectiveKeys("tui.editor.deleteCharBackward"), label: "delete search character" },
+		{ keys: effectiveKeys("app.tree.editLabel"), label: "edit label" },
+		{ keys: effectiveKeys("app.tree.filter.default"), label: "use default filter" },
+		{ keys: effectiveKeys("app.tree.filter.noTools"), label: "toggle no-tools filter" },
+		{ keys: effectiveKeys("app.tree.filter.userOnly"), label: "toggle user-only filter" },
+		{ keys: effectiveKeys("app.tree.filter.labeledOnly"), label: "toggle labeled-only filter" },
+		{ keys: effectiveKeys("app.tree.filter.all"), label: "toggle all-entries filter" },
+		{ keys: effectiveKeys("app.tree.filter.cycleForward"), label: "cycle filter forward" },
+		{ keys: effectiveKeys("app.tree.filter.cycleBackward"), label: "cycle filter backward" },
+		{ keys: ["printable text"], label: "search visible nodes" },
+		{ keys: [keys.toggleSelect], label: "toggle focused node selection" },
+		{ keys: [keys.toggleRangeSelection], label: "start or finish range selection" },
+		{ keys: [keys.copy], label: "copy focused or selected nodes" },
+		{ keys: [keys.clear], label: "clear selection" },
+		{ keys: [keys.togglePaneFocus], label: "toggle tree or preview focus" },
+		{ keys: [keys.scrollUp, keys.scrollDown], label: "scroll preview" },
+		{ keys: [keys.pageUp, keys.pageDown], label: "page preview" },
+		{ keys: [keys.toggleLabelTimestamps], label: "toggle label timestamps" },
+		{ keys: [keys.toggleEntryTimestamps], label: "toggle entry timestamps" },
+		{ keys: [keys.help], label: "show or close this help" },
+	].filter((row) => row.keys.some((key) => key.trim().length > 0));
+};

--- a/extensions/anycopy/key-help-data.ts
+++ b/extensions/anycopy/key-help-data.ts
@@ -22,6 +22,7 @@ export const formatConfiguredKey = (key: string): string => {
 	const normalized = key.trim().toLowerCase();
 	if (normalized === "space") return "Space";
 	if (normalized === "escape") return "Esc";
+	if (normalized === "type text") return "Type text";
 	if (/^f\d+$/.test(normalized)) return normalized.toUpperCase();
 	const names: Record<string, string> = {
 		shift: "Shift",
@@ -70,9 +71,15 @@ export const buildKeyHelpRows = (
 				? "navigate to focused node"
 				: "navigation unavailable, open /anycopy as a command",
 		},
-		{ keys: effectiveKeys("tui.select.cancel"), label: "clear search or close" },
+		{ keys: [keys.scrollUp, keys.scrollDown], label: "scroll preview" },
+		{ keys: [keys.pageUp, keys.pageDown], label: "page preview" },
+		{ keys: [keys.toggleRangeSelection], label: "select range" },
+		{ keys: [keys.toggleSelect], label: "(de)select node" },
+		{ keys: [keys.copy], label: "copy focused or selected nodes" },
+		{ keys: [keys.clear], label: "clear selection" },
+		{ keys: ["Type text"], label: "search visible nodes" },
 		{ keys: effectiveKeys("tui.editor.deleteCharBackward"), label: "delete search character" },
-		{ keys: effectiveKeys("app.tree.editLabel"), label: "edit label" },
+		{ keys: effectiveKeys("tui.select.cancel"), label: "clear search or close" },
 		{ keys: effectiveKeys("app.tree.filter.default"), label: "use default filter" },
 		{ keys: effectiveKeys("app.tree.filter.noTools"), label: "toggle no-tools filter" },
 		{ keys: effectiveKeys("app.tree.filter.userOnly"), label: "toggle user-only filter" },
@@ -80,14 +87,8 @@ export const buildKeyHelpRows = (
 		{ keys: effectiveKeys("app.tree.filter.all"), label: "toggle all-entries filter" },
 		{ keys: effectiveKeys("app.tree.filter.cycleForward"), label: "cycle filter forward" },
 		{ keys: effectiveKeys("app.tree.filter.cycleBackward"), label: "cycle filter backward" },
-		{ keys: ["printable text"], label: "search visible nodes" },
-		{ keys: [keys.toggleSelect], label: "toggle focused node selection" },
-		{ keys: [keys.toggleRangeSelection], label: "start or finish range selection" },
-		{ keys: [keys.copy], label: "copy focused or selected nodes" },
-		{ keys: [keys.clear], label: "clear selection" },
 		{ keys: [keys.togglePaneFocus], label: "toggle tree or preview focus" },
-		{ keys: [keys.scrollUp, keys.scrollDown], label: "scroll preview" },
-		{ keys: [keys.pageUp, keys.pageDown], label: "page preview" },
+		{ keys: effectiveKeys("app.tree.editLabel"), label: "edit label" },
 		{ keys: [keys.toggleLabelTimestamps], label: "toggle label timestamps" },
 		{ keys: [keys.toggleEntryTimestamps], label: "toggle entry timestamps" },
 		{ keys: [keys.help], label: "show or close this help" },

--- a/extensions/anycopy/key-help-data.ts
+++ b/extensions/anycopy/key-help-data.ts
@@ -1,0 +1,41 @@
+export type KeyHelpRow = {
+	keys: string[];
+	label: string;
+};
+
+export const formatConfiguredKey = (key: string): string => {
+	const normalized = key.trim().toLowerCase();
+	if (normalized === "space") return "Space";
+	if (normalized === "escape") return "Esc";
+	if (/^f\d+$/.test(normalized)) return normalized.toUpperCase();
+	const names: Record<string, string> = {
+		shift: "Shift",
+		ctrl: "Ctrl",
+		alt: "Alt",
+		enter: "Enter",
+		tab: "Tab",
+		up: "Up",
+		down: "Down",
+		left: "Left",
+		right: "Right",
+		pageup: "PageUp",
+		pagedown: "PageDown",
+		backspace: "Backspace",
+	};
+	return normalized
+		.split("+")
+		.map((part) => names[part] ?? (part.length === 1 ? part.toUpperCase() : part))
+		.join("+");
+};
+
+export const formatHelpRowKeys = (row: KeyHelpRow): string =>
+	row.keys.map(formatConfiguredKey).join(" / ");
+
+export const getKeyHelpPreferredWidth = (
+	rows: readonly KeyHelpRow[],
+	measureWidth: (text: string) => number = (text) => text.length,
+): number => {
+	const keyWidth = Math.max(3, ...rows.map((row) => measureWidth(formatHelpRowKeys(row))));
+	const actionWidth = Math.max(6, ...rows.map((row) => measureWidth(row.label)));
+	return Math.max(56, keyWidth + actionWidth + 7);
+};

--- a/extensions/anycopy/key-help-data.ts
+++ b/extensions/anycopy/key-help-data.ts
@@ -52,6 +52,7 @@ export const formatHelpRowKeys = (row: KeyHelpRow): string =>
 export const buildKeyHelpRows = (
 	getKeys: (id: string) => readonly string[],
 	keys: AnycopyHelpKeys,
+	navigationAvailable = true,
 ): KeyHelpRow[] => {
 	const effectiveKeys = (...ids: string[]): string[] =>
 		[...new Set(ids.flatMap((id) => getKeys(id)).filter((key) => key.trim().length > 0))];
@@ -63,7 +64,12 @@ export const buildKeyHelpRows = (
 		{ keys: effectiveKeys("tui.editor.cursorRight", "tui.select.pageDown"), label: "page tree down" },
 		{ keys: effectiveKeys("app.tree.foldOrUp"), label: "fold branch or jump up" },
 		{ keys: effectiveKeys("app.tree.unfoldOrDown"), label: "unfold branch or jump down" },
-		{ keys: effectiveKeys("tui.select.confirm"), label: "navigate to focused node" },
+		{
+			keys: effectiveKeys("tui.select.confirm"),
+			label: navigationAvailable
+				? "navigate to focused node"
+				: "navigation unavailable, open /anycopy as a command",
+		},
 		{ keys: effectiveKeys("tui.select.cancel"), label: "clear search or close" },
 		{ keys: effectiveKeys("tui.editor.deleteCharBackward"), label: "delete search character" },
 		{ keys: effectiveKeys("app.tree.editLabel"), label: "edit label" },

--- a/extensions/anycopy/key-help.ts
+++ b/extensions/anycopy/key-help.ts
@@ -1,64 +1,25 @@
-import type { Theme } from "@earendil-works/pi-coding-agent";
-import { matchesKey, truncateToWidth, visibleWidth, type Component } from "@earendil-works/pi-tui";
-import { formatConfiguredKey, formatHelpRowKeys, type KeyHelpRow } from "./key-help-data.ts";
+import { formatHelpRowKeys, type KeyHelpRow } from "./key-help-data.ts";
 
-export class AnycopyKeyHelp implements Component {
-	private offset = 0;
+type WrapText = (text: string, width: number) => string[];
 
-	constructor(
-		private readonly theme: Theme,
-		private readonly rows: readonly KeyHelpRow[],
-		private readonly helpKey: string,
-		private readonly getViewportHeight: () => number,
-		private readonly requestRender: () => void,
-		private readonly done: () => void,
-	) {}
+export function renderKeyHelpLines(
+	rows: readonly KeyHelpRow[],
+	width: number,
+	wrapText: WrapText,
+	decorate: (text: string) => string = (text) => text,
+): string[] {
+	const contentWidth = Math.max(1, width - 2);
+	return rows.flatMap((row) =>
+		wrapText(decorate(`${formatHelpRowKeys(row)}: ${row.label}`), contentWidth).map((line) => `  ${line}`),
+	);
+}
 
-	handleInput(data: string): void {
-		if (matchesKey(data, "escape") || matchesKey(data, this.helpKey as Parameters<typeof matchesKey>[1])) {
-			this.done();
-			return;
-		}
-		const pageSize = Math.max(1, this.getViewportHeight() - 7);
-		if (matchesKey(data, "up")) this.offset -= 1;
-		else if (matchesKey(data, "down")) this.offset += 1;
-		else if (matchesKey(data, "pageup" as Parameters<typeof matchesKey>[1])) this.offset -= pageSize;
-		else if (matchesKey(data, "pagedown" as Parameters<typeof matchesKey>[1])) this.offset += pageSize;
-		else return;
-		this.offset = Math.max(0, Math.min(this.offset, Math.max(0, this.rows.length - pageSize)));
-		this.requestRender();
-	}
-
-	private fit(text: string, width: number): string {
-		const clipped = truncateToWidth(text, width, this.theme.fg("dim", "..."));
-		return `${clipped}${" ".repeat(Math.max(0, width - visibleWidth(clipped)))}`;
-	}
-
-	render(width: number): string[] {
-		const safeWidth = Math.max(32, width);
-		const height = Math.max(8, this.getViewportHeight());
-		const bodyHeight = Math.max(1, height - 7);
-		this.offset = Math.min(this.offset, Math.max(0, this.rows.length - bodyHeight));
-		const keyWidth = Math.min(28, Math.max(12, ...this.rows.map((row) => visibleWidth(formatHelpRowKeys(row)))));
-		const actionWidth = Math.max(1, safeWidth - keyWidth - 7);
-		const rule = "─".repeat(safeWidth - 2);
-		const row = (key: string, action: string): string =>
-			`${this.theme.fg("dim", "│")} ${this.theme.fg("accent", this.fit(key, keyWidth))} ${this.theme.fg("dim", "│")} ${this.fit(action, actionWidth)} ${this.theme.fg("dim", "│")}`;
-		const visibleRows = this.rows.slice(this.offset, this.offset + bodyHeight);
-		const lines = [
-			this.theme.fg("dim", `┌${rule}┐`),
-			row("Key", "Action"),
-			this.theme.fg("dim", `├${"─".repeat(keyWidth + 2)}┼${"─".repeat(actionWidth + 2)}┤`),
-			...visibleRows.map((item) => row(formatHelpRowKeys(item), item.label)),
-		];
-		while (lines.length < height - 2) lines.push(row("", ""));
-		const range = this.rows.length > bodyHeight
-			? `${this.offset + 1}-${this.offset + visibleRows.length} of ${this.rows.length} · Up/Down scroll · `
-			: "";
-		lines.push(row("", `${range}${formatConfiguredKey(this.helpKey)}/Esc close`));
-		lines.push(this.theme.fg("dim", `└${rule}┘`));
-		return lines.slice(0, height);
-	}
-
-	invalidate(): void {}
+export function getKeyHelpWindow(totalLines: number, height: number, requestedOffset: number) {
+	const pageSize = Math.max(1, height - 2);
+	const offset = Math.max(0, Math.min(Math.floor(requestedOffset), Math.max(0, totalLines - pageSize)));
+	return {
+		offset,
+		end: Math.min(totalLines, offset + pageSize),
+		pageSize,
+	};
 }

--- a/extensions/anycopy/key-help.ts
+++ b/extensions/anycopy/key-help.ts
@@ -1,0 +1,64 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { matchesKey, truncateToWidth, visibleWidth, type Component } from "@earendil-works/pi-tui";
+import { formatConfiguredKey, formatHelpRowKeys, type KeyHelpRow } from "./key-help-data.ts";
+
+export class AnycopyKeyHelp implements Component {
+	private offset = 0;
+
+	constructor(
+		private readonly theme: Theme,
+		private readonly rows: readonly KeyHelpRow[],
+		private readonly helpKey: string,
+		private readonly getViewportHeight: () => number,
+		private readonly requestRender: () => void,
+		private readonly done: () => void,
+	) {}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, "escape") || matchesKey(data, this.helpKey as Parameters<typeof matchesKey>[1])) {
+			this.done();
+			return;
+		}
+		const pageSize = Math.max(1, this.getViewportHeight() - 7);
+		if (matchesKey(data, "up")) this.offset -= 1;
+		else if (matchesKey(data, "down")) this.offset += 1;
+		else if (matchesKey(data, "pageup" as Parameters<typeof matchesKey>[1])) this.offset -= pageSize;
+		else if (matchesKey(data, "pagedown" as Parameters<typeof matchesKey>[1])) this.offset += pageSize;
+		else return;
+		this.offset = Math.max(0, Math.min(this.offset, Math.max(0, this.rows.length - pageSize)));
+		this.requestRender();
+	}
+
+	private fit(text: string, width: number): string {
+		const clipped = truncateToWidth(text, width, this.theme.fg("dim", "..."));
+		return `${clipped}${" ".repeat(Math.max(0, width - visibleWidth(clipped)))}`;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(32, width);
+		const height = Math.max(8, this.getViewportHeight());
+		const bodyHeight = Math.max(1, height - 7);
+		this.offset = Math.min(this.offset, Math.max(0, this.rows.length - bodyHeight));
+		const keyWidth = Math.min(28, Math.max(12, ...this.rows.map((row) => visibleWidth(formatHelpRowKeys(row)))));
+		const actionWidth = Math.max(1, safeWidth - keyWidth - 7);
+		const rule = "─".repeat(safeWidth - 2);
+		const row = (key: string, action: string): string =>
+			`${this.theme.fg("dim", "│")} ${this.theme.fg("accent", this.fit(key, keyWidth))} ${this.theme.fg("dim", "│")} ${this.fit(action, actionWidth)} ${this.theme.fg("dim", "│")}`;
+		const visibleRows = this.rows.slice(this.offset, this.offset + bodyHeight);
+		const lines = [
+			this.theme.fg("dim", `┌${rule}┐`),
+			row("Key", "Action"),
+			this.theme.fg("dim", `├${"─".repeat(keyWidth + 2)}┼${"─".repeat(actionWidth + 2)}┤`),
+			...visibleRows.map((item) => row(formatHelpRowKeys(item), item.label)),
+		];
+		while (lines.length < height - 2) lines.push(row("", ""));
+		const range = this.rows.length > bodyHeight
+			? `${this.offset + 1}-${this.offset + visibleRows.length} of ${this.rows.length} · Up/Down scroll · `
+			: "";
+		lines.push(row("", `${range}${formatConfiguredKey(this.helpKey)}/Esc close`));
+		lines.push(this.theme.fg("dim", `└${rule}┘`));
+		return lines.slice(0, height);
+	}
+
+	invalidate(): void {}
+}

--- a/extensions/anycopy/status-hints.ts
+++ b/extensions/anycopy/status-hints.ts
@@ -1,0 +1,13 @@
+type WrapText = (text: string, width: number) => string[];
+
+export function renderStatusHints(
+	segments: readonly string[],
+	width: number,
+	wrapText: WrapText,
+	decorate: (text: string) => string = (text) => text,
+): string[] {
+	const padding = "  ";
+	return wrapText(decorate(segments.join(" · ")), Math.max(1, width - padding.length)).map(
+		(line) => `${padding}${line}`,
+	);
+}

--- a/extensions/anycopy/status-hints.ts
+++ b/extensions/anycopy/status-hints.ts
@@ -1,4 +1,14 @@
+export type HintMode = "full" | "compact";
+
 type WrapText = (text: string, width: number) => string[];
+
+export function buildStatusTextLines(
+	mode: HintMode,
+	status: string,
+	hintLines: readonly string[],
+): string[] {
+	return mode === "compact" ? [`  ${status}`] : [`  ${status}`, ...hintLines];
+}
 
 export function renderStatusHints(
 	segments: readonly string[],

--- a/extensions/anycopy/test/custom-entry.test.ts
+++ b/extensions/anycopy/test/custom-entry.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatCustomEntryContent, formatCustomEntryPreview } from "../custom-entry.ts";
+
+test("formatCustomEntryContent includes persisted object data", () => {
+	assert.equal(
+		formatCustomEntryContent("system-prompt-request-evidence", {
+			requestId: "req-1",
+			accepted: true,
+		}),
+		"Custom entry: system-prompt-request-evidence\n\nRequest id: req-1\nAccepted: true",
+	);
+});
+
+test("formatCustomEntryContent preserves string data", () => {
+	assert.equal(formatCustomEntryContent("note", "body"), "Custom entry: note\n\nbody");
+});
+
+test("formatCustomEntryContent keeps a useful fallback when data is absent", () => {
+	assert.equal(formatCustomEntryContent("marker", undefined), "Custom entry: marker");
+});
+
+test("formatCustomEntryPreview renders structured evidence in local time as readable markdown", () => {
+	const previousTimeZone = process.env.TZ;
+	process.env.TZ = "Europe/Moscow";
+	try {
+		const preview = formatCustomEntryPreview("system-prompt-request-evidence", {
+			capturedAt: 1786757631626,
+			promptKind: "coordinator",
+			chars: 44823,
+			contextFiles: [{ path: "/home/adams/.pi/agent/AGENTS.md", chars: 1309 }],
+			provenance: { capture: "before_provider_request" },
+		});
+
+		assert.match(preview, /^\*\*Custom entry:\*\* `system-prompt-request-evidence`/);
+		assert.match(preview, /\*\*Captured at:\*\* 15 Aug 2026, 04:33:51 GMT\+3/);
+		assert.match(preview, /\*\*Characters:\*\* 44,823/);
+		assert.match(preview, /\*\*Context files \(1\)\*\*/);
+		assert.match(preview, /1\. \/home\/adams\/\.pi\/agent\/AGENTS\.md/);
+		assert.doesNotMatch(preview, /\n\s*1\.\s*\n/);
+		assert.match(preview, /\*\*Provenance\*\*/);
+	} finally {
+		if (previousTimeZone === undefined) delete process.env.TZ;
+		else process.env.TZ = previousTimeZone;
+	}
+});

--- a/extensions/anycopy/test/custom-entry.test.ts
+++ b/extensions/anycopy/test/custom-entry.test.ts
@@ -20,6 +20,13 @@ test("formatCustomEntryContent keeps a useful fallback when data is absent", () 
 	assert.equal(formatCustomEntryContent("marker", undefined), "Custom entry: marker");
 });
 
+test("formatCustomEntryContent keeps lowercase at suffixes numeric", () => {
+	assert.equal(
+		formatCustomEntryContent("metrics", { stat: 42, format: 7 }),
+		"Custom entry: metrics\n\nStat: 42\nFormat: 7",
+	);
+});
+
 test("formatCustomEntryPreview renders structured evidence in local time as readable markdown", () => {
 	const previousTimeZone = process.env.TZ;
 	process.env.TZ = "Europe/Moscow";

--- a/extensions/anycopy/test/interaction-state.test.ts
+++ b/extensions/anycopy/test/interaction-state.test.ts
@@ -7,10 +7,10 @@ test("togglePaneFocus switches between the two fixed layouts", () => {
 	assert.equal(togglePaneFocus("preview"), "tree");
 });
 
-test("applyInclusiveRangeSelection toggles a forward range against its baseline", () => {
+test("applyInclusiveRangeSelection adds a forward range to its baseline", () => {
 	assert.deepEqual(
 		[...applyInclusiveRangeSelection(new Set(["outside", "b"]), ["a", "b", "c", "d"], "b", "d")],
-		["outside", "c", "d"],
+		["outside", "b", "c", "d"],
 	);
 });
 

--- a/extensions/anycopy/test/interaction-state.test.ts
+++ b/extensions/anycopy/test/interaction-state.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyInclusiveRangeSelection, togglePaneFocus } from "../interaction-state.ts";
+
+test("togglePaneFocus switches between the two fixed layouts", () => {
+	assert.equal(togglePaneFocus("tree"), "preview");
+	assert.equal(togglePaneFocus("preview"), "tree");
+});
+
+test("applyInclusiveRangeSelection toggles a forward range against its baseline", () => {
+	assert.deepEqual(
+		[...applyInclusiveRangeSelection(new Set(["outside", "b"]), ["a", "b", "c", "d"], "b", "d")],
+		["outside", "c", "d"],
+	);
+});
+
+test("applyInclusiveRangeSelection shrinks and reverses around the anchor", () => {
+	const baseline = new Set(["outside"]);
+	assert.deepEqual(
+		[...applyInclusiveRangeSelection(baseline, ["a", "b", "c", "d"], "c", "a")],
+		["outside", "a", "b", "c"],
+	);
+	assert.deepEqual(
+		[...applyInclusiveRangeSelection(baseline, ["a", "b", "c", "d"], "c", "b")],
+		["outside", "b", "c"],
+	);
+});
+
+test("applyInclusiveRangeSelection preserves the baseline when an endpoint is hidden", () => {
+	assert.deepEqual(
+		[...applyInclusiveRangeSelection(new Set(["saved"]), ["a", "b"], "hidden", "b")],
+		["saved"],
+	);
+});

--- a/extensions/anycopy/test/key-help.test.ts
+++ b/extensions/anycopy/test/key-help.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatConfiguredKey, formatHelpRowKeys, getKeyHelpPreferredWidth } from "../key-help-data.ts";
+
+test("help spells every modifier out", () => {
+	assert.equal(formatConfiguredKey("shift+ctrl+t"), "Shift+Ctrl+T");
+	assert.equal(formatConfiguredKey("shift+pageup"), "Shift+PageUp");
+	assert.equal(formatConfiguredKey("escape"), "Esc");
+});
+
+test("help formats all effective keys for an action", () => {
+	assert.equal(
+		formatHelpRowKeys({ keys: ["ctrl+left", "alt+left"], label: "fold" }),
+		"Ctrl+Left / Alt+Left",
+	);
+});
+
+test("preferred width includes key and action columns", () => {
+	assert.equal(getKeyHelpPreferredWidth([{ keys: ["?"], label: "show help" }]), 56);
+	assert.ok(
+		getKeyHelpPreferredWidth([
+			{ keys: ["shift+ctrl+pageup"], label: "a deliberately long action label that exceeds the minimum width" },
+		]) > 56,
+	);
+});

--- a/extensions/anycopy/test/key-help.test.ts
+++ b/extensions/anycopy/test/key-help.test.ts
@@ -1,12 +1,44 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { getKeyHelpWindow, renderKeyHelpLines } from "../key-help.ts";
-import { formatConfiguredKey, formatHelpRowKeys } from "../key-help-data.ts";
+import { buildKeyHelpRows, formatConfiguredKey, formatHelpRowKeys } from "../key-help-data.ts";
 
 test("help spells every modifier out", () => {
 	assert.equal(formatConfiguredKey("shift+ctrl+t"), "Shift+Ctrl+T");
 	assert.equal(formatConfiguredKey("shift+pageup"), "Shift+PageUp");
 	assert.equal(formatConfiguredKey("escape"), "Esc");
+	assert.equal(formatConfiguredKey("super+shift+p"), "Super+Shift+P");
+});
+
+test("help includes effective native and anycopy actions but omits native Ctrl+X copy", () => {
+	const nativeKeys = new Map<string, string[]>([
+		["tui.select.up", ["up"]],
+		["app.message.copy", ["ctrl+x"]],
+		["app.tree.editLabel", ["shift+l"]],
+	]);
+	const rows = buildKeyHelpRows(
+		(id) => nativeKeys.get(id) ?? [],
+		{
+			toggleSelect: "shift+a",
+			copy: "shift+c",
+			clear: "shift+x",
+			toggleLabelTimestamps: "shift+t",
+			toggleEntryTimestamps: "shift+ctrl+t",
+			scrollDown: "shift+down",
+			scrollUp: "shift+up",
+			pageDown: "shift+pagedown",
+			pageUp: "shift+pageup",
+			togglePaneFocus: "tab",
+			toggleRangeSelection: "shift+r",
+			help: "?",
+		},
+	);
+
+	assert.deepEqual(rows.find((row) => row.label === "move up")?.keys, ["up"]);
+	assert.deepEqual(rows.find((row) => row.label === "edit label")?.keys, ["shift+l"]);
+	assert.deepEqual(rows.find((row) => row.label === "copy focused or selected nodes")?.keys, ["shift+c"]);
+	assert.equal(rows.some((row) => row.keys.length === 0), false);
+	assert.equal(rows.flatMap((row) => row.keys).includes("ctrl+x"), false);
 });
 
 test("help formats all effective keys for an action", () => {

--- a/extensions/anycopy/test/key-help.test.ts
+++ b/extensions/anycopy/test/key-help.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { formatConfiguredKey, formatHelpRowKeys, getKeyHelpPreferredWidth } from "../key-help-data.ts";
+import { getKeyHelpWindow, renderKeyHelpLines } from "../key-help.ts";
+import { formatConfiguredKey, formatHelpRowKeys } from "../key-help-data.ts";
 
 test("help spells every modifier out", () => {
 	assert.equal(formatConfiguredKey("shift+ctrl+t"), "Shift+Ctrl+T");
@@ -15,11 +16,20 @@ test("help formats all effective keys for an action", () => {
 	);
 });
 
-test("preferred width includes key and action columns", () => {
-	assert.equal(getKeyHelpPreferredWidth([{ keys: ["?"], label: "show help" }]), 56);
-	assert.ok(
-		getKeyHelpPreferredWidth([
-			{ keys: ["shift+ctrl+pageup"], label: "a deliberately long action label that exceeds the minimum width" },
-		]) > 56,
+test("embedded help renders native-style padded lines without modal chrome", () => {
+	const lines = renderKeyHelpLines(
+		[{ keys: ["shift+r"], label: "start or finish range selection" }],
+		80,
+		(text) => [text],
 	);
+	assert.deepEqual(lines, ["  Shift+R: start or finish range selection"]);
+	assert.equal(lines.some((line) => /[┌┐└┘│]/.test(line)), false);
+});
+
+test("embedded help window reserves heading and footer rows", () => {
+	assert.deepEqual(getKeyHelpWindow(20, 10, 99), {
+		offset: 12,
+		end: 20,
+		pageSize: 8,
+	});
 });

--- a/extensions/anycopy/test/key-help.test.ts
+++ b/extensions/anycopy/test/key-help.test.ts
@@ -41,6 +41,32 @@ test("help includes effective native and anycopy actions but omits native Ctrl+X
 	assert.equal(rows.flatMap((row) => row.keys).includes("ctrl+x"), false);
 });
 
+test("shortcut-opened help explains that Enter cannot navigate", () => {
+	const rows = buildKeyHelpRows(
+		(id) => id === "tui.select.confirm" ? ["enter"] : [],
+		{
+			toggleSelect: "shift+a",
+			copy: "shift+c",
+			clear: "shift+x",
+			toggleLabelTimestamps: "shift+t",
+			toggleEntryTimestamps: "shift+ctrl+t",
+			scrollDown: "shift+down",
+			scrollUp: "shift+up",
+			pageDown: "shift+pagedown",
+			pageUp: "shift+pageup",
+			togglePaneFocus: "tab",
+			toggleRangeSelection: "shift+r",
+			help: "?",
+		},
+		false,
+	);
+
+	assert.deepEqual(rows.find((row) => row.keys.includes("enter")), {
+		keys: ["enter"],
+		label: "navigation unavailable, open /anycopy as a command",
+	});
+});
+
 test("help formats all effective keys for an action", () => {
 	assert.equal(
 		formatHelpRowKeys({ keys: ["ctrl+left", "alt+left"], label: "fold" }),

--- a/extensions/anycopy/test/key-help.test.ts
+++ b/extensions/anycopy/test/key-help.test.ts
@@ -67,6 +67,77 @@ test("shortcut-opened help explains that Enter cannot navigate", () => {
 	});
 });
 
+test("help groups tree, preview, selection, search, and layout actions", () => {
+	const nativeKeys = new Map<string, string[]>([
+		["tui.select.up", ["up"]],
+		["tui.select.down", ["down"]],
+		["tui.editor.cursorLeft", ["left"]],
+		["tui.editor.cursorRight", ["right"]],
+		["app.tree.foldOrUp", ["ctrl+left"]],
+		["app.tree.unfoldOrDown", ["ctrl+right"]],
+		["tui.select.confirm", ["enter"]],
+		["tui.editor.deleteCharBackward", ["backspace"]],
+		["tui.select.cancel", ["escape"]],
+		["app.tree.filter.default", ["ctrl+1"]],
+		["app.tree.filter.noTools", ["ctrl+2"]],
+		["app.tree.filter.userOnly", ["ctrl+3"]],
+		["app.tree.filter.labeledOnly", ["ctrl+4"]],
+		["app.tree.filter.all", ["ctrl+5"]],
+		["app.tree.filter.cycleForward", ["]"]],
+		["app.tree.filter.cycleBackward", ["["]],
+		["app.tree.editLabel", ["shift+l"]],
+	]);
+	const rows = buildKeyHelpRows(
+		(id) => nativeKeys.get(id) ?? [],
+		{
+			toggleSelect: "shift+a",
+			copy: "shift+c",
+			clear: "shift+x",
+			toggleLabelTimestamps: "shift+t",
+			toggleEntryTimestamps: "shift+ctrl+t",
+			scrollDown: "shift+down",
+			scrollUp: "shift+up",
+			pageDown: "shift+pagedown",
+			pageUp: "shift+pageup",
+			togglePaneFocus: "tab",
+			toggleRangeSelection: "shift+r",
+			help: "?",
+		},
+	);
+
+	assert.deepEqual(rows.map((row) => row.label), [
+		"move up",
+		"move down",
+		"page tree up",
+		"page tree down",
+		"fold branch or jump up",
+		"unfold branch or jump down",
+		"navigate to focused node",
+		"scroll preview",
+		"page preview",
+		"select range",
+		"(de)select node",
+		"copy focused or selected nodes",
+		"clear selection",
+		"search visible nodes",
+		"delete search character",
+		"clear search or close",
+		"use default filter",
+		"toggle no-tools filter",
+		"toggle user-only filter",
+		"toggle labeled-only filter",
+		"toggle all-entries filter",
+		"cycle filter forward",
+		"cycle filter backward",
+		"toggle tree or preview focus",
+		"edit label",
+		"toggle label timestamps",
+		"toggle entry timestamps",
+		"show or close this help",
+	]);
+	assert.equal(rows[13] ? formatHelpRowKeys(rows[13]) : undefined, "Type text");
+});
+
 test("help formats all effective keys for an action", () => {
 	assert.equal(
 		formatHelpRowKeys({ keys: ["ctrl+left", "alt+left"], label: "fold" }),
@@ -76,11 +147,11 @@ test("help formats all effective keys for an action", () => {
 
 test("embedded help renders native-style padded lines without modal chrome", () => {
 	const lines = renderKeyHelpLines(
-		[{ keys: ["shift+r"], label: "start or finish range selection" }],
+		[{ keys: ["shift+r"], label: "select range" }],
 		80,
 		(text) => [text],
 	);
-	assert.deepEqual(lines, ["  Shift+R: start or finish range selection"]);
+	assert.deepEqual(lines, ["  Shift+R: select range"]);
 	assert.equal(lines.some((line) => /[┌┐└┘│]/.test(line)), false);
 });
 

--- a/extensions/anycopy/test/status-hints.test.ts
+++ b/extensions/anycopy/test/status-hints.test.ts
@@ -6,8 +6,8 @@ const segments = [
 	"Shift+Up/Shift+Down: scroll preview",
 	"Shift+PageUp/Shift+PageDown: page preview",
 	"Enter: navigate",
-	"Shift+R: range",
-	"Shift+A: select",
+	"Shift+R: select range",
+	"Shift+A: (de)select node",
 	"Shift+C: copy",
 	"Shift+X: clear",
 	"Tab: layout",
@@ -31,7 +31,7 @@ test("full hints retain the status row and every wrapped hint row", () => {
 test("status hints delegate the complete text to the native wrapper", () => {
 	const wrapped = [
 		"Shift+Up/Shift+Down: scroll preview · Shift+PageUp/Shift+PageDown: page",
-		"preview · Enter: navigate · Shift+R: range · Shift+A: select · Shift+C: copy ·",
+		"preview · Enter: navigate · Shift+R: select range · Shift+A: (de)select node ·",
 		"Shift+X: clear · Tab: layout · ?: help",
 	];
 	let receivedText = "";

--- a/extensions/anycopy/test/status-hints.test.ts
+++ b/extensions/anycopy/test/status-hints.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderStatusHints } from "../status-hints.ts";
+
+const segments = [
+	"Shift+Up/Shift+Down: scroll preview",
+	"Shift+PageUp/Shift+PageDown: page preview",
+	"Enter: navigate",
+	"Shift+R: range",
+	"Shift+A: select",
+	"Shift+C: copy",
+	"Shift+X: clear",
+	"Tab: layout",
+	"?: help",
+];
+
+test("status hints delegate the complete text to the native wrapper", () => {
+	const wrapped = [
+		"Shift+Up/Shift+Down: scroll preview · Shift+PageUp/Shift+PageDown: page",
+		"preview · Enter: navigate · Shift+R: range · Shift+A: select · Shift+C: copy ·",
+		"Shift+X: clear · Tab: layout · ?: help",
+	];
+	let receivedText = "";
+	let receivedWidth = 0;
+	const lines = renderStatusHints(segments, 80, (text, width) => {
+		receivedText = text;
+		receivedWidth = width;
+		return wrapped;
+	});
+
+	assert.equal(receivedText, segments.join(" · "));
+	assert.equal(receivedWidth, 78);
+	assert.deepEqual(lines, wrapped.map((line) => `  ${line}`));
+	assert.equal(lines.join(" ").includes("?: help"), true);
+});

--- a/extensions/anycopy/test/status-hints.test.ts
+++ b/extensions/anycopy/test/status-hints.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderStatusHints } from "../status-hints.ts";
+import { buildStatusTextLines, renderStatusHints } from "../status-hints.ts";
 
 const segments = [
 	"Shift+Up/Shift+Down: scroll preview",
@@ -13,6 +13,20 @@ const segments = [
 	"Tab: layout",
 	"?: help",
 ];
+
+test("compact hints keep one fixed status row", () => {
+	assert.deepEqual(buildStatusTextLines("compact", "?: help · Enter: navigate", ["  Shift+C: copy"]), [
+		"  ?: help · Enter: navigate",
+	]);
+});
+
+test("full hints retain the status row and every wrapped hint row", () => {
+	assert.deepEqual(buildStatusTextLines("full", "Ready", ["  Shift+C: copy", "  Shift+X: clear"]), [
+		"  Ready",
+		"  Shift+C: copy",
+		"  Shift+X: clear",
+	]);
+});
 
 test("status hints delegate the complete text to the native wrapper", () => {
 	const wrapped = [

--- a/extensions/anycopy/test/tool-call-copy.test.ts
+++ b/extensions/anycopy/test/tool-call-copy.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { formatToolCallResultForClipboard, resolveToolCallFromParents } from "../tool-call-copy.ts";
+
+type Node = { entry: SessionEntry };
+const entry = (value: Record<string, unknown>): SessionEntry => value as unknown as SessionEntry;
+const assistant = entry({
+	type: "message",
+	id: "assistant",
+	parentId: "root",
+	message: {
+		role: "assistant",
+		content: [
+			{ type: "toolCall", id: "call-a", name: "read", arguments: { path: "a.ts" } },
+			{ type: "toolCall", id: "call-b", name: "grep", arguments: { pattern: "needle" } },
+		],
+	},
+});
+const nodes = new Map<string, Node>([["assistant", { entry: assistant }]]);
+
+test("resolveToolCallFromParents matches the exact call id", () => {
+	const result = entry({
+		type: "message",
+		id: "result",
+		parentId: "assistant",
+		message: { role: "toolResult", toolCallId: "call-b", toolName: "grep", content: [] },
+	});
+	assert.deepEqual(resolveToolCallFromParents(result, nodes), {
+		name: "grep",
+		arguments: { pattern: "needle" },
+	});
+});
+
+test("tool result copy always includes its matching invocation and readable result", () => {
+	const result = entry({
+		type: "message",
+		id: "result",
+		parentId: "assistant",
+		message: {
+			role: "toolResult",
+			toolCallId: "call-a",
+			toolName: "read",
+			content: [{ type: "text", text: "file body" }],
+			details: { internal: true },
+		},
+	});
+	assert.equal(
+		formatToolCallResultForClipboard(result, nodes),
+		`toolCall:\n\n{\n  "name": "read",\n  "arguments": {\n    "path": "a.ts"\n  }\n}\n\ntoolResult:\n\nfile body`,
+	);
+});
+
+test("ordinary nodes do not acquire a synthetic tool invocation", () => {
+	assert.equal(formatToolCallResultForClipboard(assistant, nodes), null);
+});

--- a/extensions/anycopy/test/tool-call-copy.test.ts
+++ b/extensions/anycopy/test/tool-call-copy.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
-import { formatToolCallResultForClipboard, resolveToolCallFromParents } from "../tool-call-copy.ts";
+import {
+	formatJsonForDisplay,
+	formatToolCallResultForClipboard,
+	resolveToolCallFromParents,
+} from "../tool-call-copy.ts";
 
 type Node = { entry: SessionEntry };
 const entry = (value: Record<string, unknown>): SessionEntry => value as unknown as SessionEntry;
@@ -53,4 +57,46 @@ test("tool result copy always includes its matching invocation and readable resu
 
 test("ordinary nodes do not acquire a synthetic tool invocation", () => {
 	assert.equal(formatToolCallResultForClipboard(assistant, nodes), null);
+});
+
+test("tool call lookup handles parent chains deeper than thirty entries", () => {
+	const deepNodes = new Map(nodes);
+	let parentId = "assistant";
+	for (let index = 0; index < 40; index += 1) {
+		const id = `intermediate-${index}`;
+		deepNodes.set(id, { entry: entry({ type: "custom", id, parentId }) });
+		parentId = id;
+	}
+	const result = entry({
+		type: "message",
+		id: "deep-result",
+		parentId,
+		message: { role: "toolResult", toolCallId: "call-a", toolName: "read", content: [] },
+	});
+
+	assert.deepEqual(resolveToolCallFromParents(result, deepNodes), {
+		name: "read",
+		arguments: { path: "a.ts" },
+	});
+});
+
+test("tool call lookup terminates on malformed parent cycles", () => {
+	const cyclicNodes = new Map<string, Node>([
+		["cycle-a", { entry: entry({ type: "custom", id: "cycle-a", parentId: "cycle-b" }) }],
+		["cycle-b", { entry: entry({ type: "custom", id: "cycle-b", parentId: "cycle-a" }) }],
+	]);
+	const result = entry({
+		type: "message",
+		id: "result",
+		parentId: "cycle-a",
+		message: { role: "toolResult", toolCallId: "call-a", toolName: "read", content: [] },
+	});
+
+	assert.equal(resolveToolCallFromParents(result, cyclicNodes), null);
+});
+
+test("JSON display formatting degrades safely for unserializable values", () => {
+	const cyclic: Record<string, unknown> = {};
+	cyclic.self = cyclic;
+	assert.equal(formatJsonForDisplay(cyclic), "[unserializable]");
 });

--- a/extensions/anycopy/test/viewport-layout.test.ts
+++ b/extensions/anycopy/test/viewport-layout.test.ts
@@ -1,29 +1,28 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-
 import {
 	getAnycopyRenderHeight,
 	getAnycopyTreeHeight,
 	getAnycopyTreeVisibleLines,
 } from "../viewport-layout.ts";
 
-test("getAnycopyRenderHeight reserves two terminal rows below the overlay", () => {
+test("getAnycopyRenderHeight reserves two terminal rows", () => {
 	assert.equal(getAnycopyRenderHeight(40), 38);
-});
-
-test("getAnycopyRenderHeight floors fractional terminal heights", () => {
-	assert.equal(getAnycopyRenderHeight(40.9), 38);
-});
-
-test("getAnycopyRenderHeight always leaves at least one component row", () => {
 	assert.equal(getAnycopyRenderHeight(1), 1);
 });
 
-test("getAnycopyTreeHeight applies the selector height ratio", () => {
+test("getAnycopyTreeHeight keeps the initial selector allocation", () => {
 	assert.equal(getAnycopyTreeHeight(38), 24);
 });
 
-test("getAnycopyTreeVisibleLines follows the live render height", () => {
-	assert.equal(getAnycopyTreeVisibleLines(38), 12);
-	assert.equal(getAnycopyTreeVisibleLines(18), 5);
+test("tree-focused and preview-focused layouts use their configured ratios", () => {
+	const ratios = { tree: 0.8, preview: 0.2 };
+	assert.equal(getAnycopyTreeVisibleLines(20, "tree", ratios), 16);
+	assert.equal(getAnycopyTreeVisibleLines(20, "preview", ratios), 4);
+});
+
+test("both layouts retain at least one row for each pane", () => {
+	const ratios = { tree: 0.99, preview: 0.01 };
+	assert.equal(getAnycopyTreeVisibleLines(2, "tree", ratios), 1);
+	assert.equal(getAnycopyTreeVisibleLines(2, "preview", ratios), 1);
 });

--- a/extensions/anycopy/tool-call-copy.ts
+++ b/extensions/anycopy/tool-call-copy.ts
@@ -1,0 +1,75 @@
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+
+export type ToolCallInvocation = {
+	name: string;
+	arguments: Record<string, unknown>;
+};
+
+type SessionTreeNodeLike = {
+	entry: SessionEntry;
+};
+
+const MAX_PARENT_TRAVERSAL_DEPTH = 30;
+
+export const getToolName = (entry: SessionEntry): string | null => {
+	if (entry.type !== "message") return null;
+	const message = entry.message as { role?: string; toolName?: unknown };
+	if (message.role !== "toolResult") return null;
+	return typeof message.toolName === "string" ? message.toolName : null;
+};
+
+export const resolveToolCallFromParents = (
+	entry: SessionEntry,
+	nodeById: ReadonlyMap<string, SessionTreeNodeLike>,
+): ToolCallInvocation | null => {
+	if (entry.type !== "message") return null;
+	const resultMessage = entry.message as { role?: string; toolCallId?: unknown };
+	if (resultMessage.role !== "toolResult" || typeof resultMessage.toolCallId !== "string") return null;
+
+	let parentId = entry.parentId;
+	for (let depth = 0; depth < MAX_PARENT_TRAVERSAL_DEPTH && parentId; depth += 1) {
+		const parentEntry = nodeById.get(parentId)?.entry;
+		if (!parentEntry) return null;
+		if (parentEntry.type === "message") {
+			const message = parentEntry.message as { role?: string; content?: unknown };
+			if (message.role === "assistant" && Array.isArray(message.content)) {
+				const block = message.content.find((candidate: unknown) => {
+					if (typeof candidate !== "object" || candidate === null) return false;
+					const value = candidate as Record<string, unknown>;
+					return value.type === "toolCall" && value.id === resultMessage.toolCallId &&
+						typeof value.name === "string" && typeof value.arguments === "object" &&
+						value.arguments !== null && !Array.isArray(value.arguments);
+				}) as { name: string; arguments: Record<string, unknown> } | undefined;
+				if (block) return { name: block.name, arguments: block.arguments };
+			}
+		}
+		parentId = parentEntry.parentId;
+	}
+	return null;
+};
+
+const formatResultContent = (content: unknown): string => {
+	if (typeof content === "string") return content;
+	if (Array.isArray(content)) {
+		if (content.length === 0) return "[]";
+		const textBlocks = content.filter(
+			(block): block is { type: "text"; text: string } =>
+				typeof block === "object" && block !== null &&
+				(block as { type?: unknown }).type === "text" &&
+				typeof (block as { text?: unknown }).text === "string",
+		);
+		if (textBlocks.length === content.length) return textBlocks.map((block) => block.text).join("");
+	}
+	return JSON.stringify(content ?? [], null, 2);
+};
+
+export const formatToolCallResultForClipboard = (
+	entry: SessionEntry,
+	nodeById: ReadonlyMap<string, SessionTreeNodeLike>,
+): string | null => {
+	const invocation = resolveToolCallFromParents(entry, nodeById);
+	if (!invocation || entry.type !== "message") return null;
+	const message = entry.message as { content?: unknown; isError?: boolean };
+	const resultLabel = message.isError === true ? "toolResult (error)" : "toolResult";
+	return `toolCall:\n\n${JSON.stringify(invocation, null, 2)}\n\n${resultLabel}:\n\n${formatResultContent(message.content)}`;
+};

--- a/extensions/anycopy/tool-call-copy.ts
+++ b/extensions/anycopy/tool-call-copy.ts
@@ -9,8 +9,6 @@ type SessionTreeNodeLike = {
 	entry: SessionEntry;
 };
 
-const MAX_PARENT_TRAVERSAL_DEPTH = 30;
-
 export const getToolName = (entry: SessionEntry): string | null => {
 	if (entry.type !== "message") return null;
 	const message = entry.message as { role?: string; toolName?: unknown };
@@ -27,7 +25,11 @@ export const resolveToolCallFromParents = (
 	if (resultMessage.role !== "toolResult" || typeof resultMessage.toolCallId !== "string") return null;
 
 	let parentId = entry.parentId;
-	for (let depth = 0; depth < MAX_PARENT_TRAVERSAL_DEPTH && parentId; depth += 1) {
+	const visitedParentIds = new Set<string>();
+	while (parentId) {
+		if (visitedParentIds.has(parentId)) return null;
+		visitedParentIds.add(parentId);
+
 		const parentEntry = nodeById.get(parentId)?.entry;
 		if (!parentEntry) return null;
 		if (parentEntry.type === "message") {
@@ -48,6 +50,14 @@ export const resolveToolCallFromParents = (
 	return null;
 };
 
+export const formatJsonForDisplay = (value: unknown): string => {
+	try {
+		return JSON.stringify(value, null, 2) ?? "null";
+	} catch {
+		return "[unserializable]";
+	}
+};
+
 const formatResultContent = (content: unknown): string => {
 	if (typeof content === "string") return content;
 	if (Array.isArray(content)) {
@@ -60,7 +70,7 @@ const formatResultContent = (content: unknown): string => {
 		);
 		if (textBlocks.length === content.length) return textBlocks.map((block) => block.text).join("");
 	}
-	return JSON.stringify(content ?? [], null, 2);
+	return formatJsonForDisplay(content ?? []);
 };
 
 export const formatToolCallResultForClipboard = (
@@ -71,5 +81,5 @@ export const formatToolCallResultForClipboard = (
 	if (!invocation || entry.type !== "message") return null;
 	const message = entry.message as { content?: unknown; isError?: boolean };
 	const resultLabel = message.isError === true ? "toolResult (error)" : "toolResult";
-	return `toolCall:\n\n${JSON.stringify(invocation, null, 2)}\n\n${resultLabel}:\n\n${formatResultContent(message.content)}`;
+	return `toolCall:\n\n${formatJsonForDisplay(invocation)}\n\n${resultLabel}:\n\n${formatResultContent(message.content)}`;
 };

--- a/extensions/anycopy/viewport-layout.ts
+++ b/extensions/anycopy/viewport-layout.ts
@@ -1,16 +1,24 @@
-// Reserve the bottom two terminal rows below the bounded overlay. In fullscreen
-// mode, those rows contain Pi's final two footer rows.
+import type { PaneFocus } from "./interaction-state.ts";
+
 const HOST_RESERVED_ROWS = 2;
-const TREE_HEIGHT_RATIO = 0.65;
+const INITIAL_TREE_RATIO = 0.65;
+
+export type PaneLayoutRatios = Record<PaneFocus, number>;
 
 export function getAnycopyRenderHeight(terminalRows: number): number {
 	return Math.max(1, Math.floor(terminalRows) - HOST_RESERVED_ROWS);
 }
 
 export function getAnycopyTreeHeight(renderHeight: number): number {
-	return Math.floor(renderHeight * TREE_HEIGHT_RATIO);
+	return Math.max(1, Math.floor(renderHeight * INITIAL_TREE_RATIO));
 }
 
-export function getAnycopyTreeVisibleLines(renderHeight: number): number {
-	return Math.max(5, Math.floor(getAnycopyTreeHeight(renderHeight) / 2));
+export function getAnycopyTreeVisibleLines(
+	availableRows: number,
+	paneFocus: PaneFocus = "tree",
+	ratios: PaneLayoutRatios = { tree: 0.85, preview: 0.15 },
+): number {
+	const rows = Math.max(1, Math.floor(availableRows));
+	if (rows === 1) return 1;
+	return Math.max(1, Math.min(rows - 1, Math.round(rows * ratios[paneFocus])));
 }

--- a/packages/pi-anycopy/README.md
+++ b/packages/pi-anycopy/README.md
@@ -48,13 +48,16 @@ Defaults (customizable in `config.json`):
 |-----|--------|
 | `Enter` | Navigate to the focused node (same semantics as `/tree`) |
 | `Shift+A` | Select/unselect focused node for copy |
-| `Shift+C` | Copy selected nodes, or the focused node if nothing is selected |
+| `Shift+C` | Copy selected nodes, or the focused node if nothing is selected. Tool results include the originating call |
 | `Shift+X` | Clear selection |
+| `Shift+R` | Start or finish inclusive range selection |
+| `Tab` | Toggle between tree-focused and preview-focused layouts |
 | `Shift+L` | Label node (native tree behavior) |
 | `Shift+T` | Toggle label timestamps for labeled nodes |
 | `Shift+Ctrl+T` | Toggle node creation timestamps |
 | `Shift+Up` / `Shift+Down` | Scroll node preview by line |
 | `Shift+PageUp` / `Shift+PageDown` | Page through node preview |
+| `?` | Show every effective native tree and anycopy action |
 | `Esc` | Close |
 
 Notes:
@@ -64,6 +67,11 @@ Notes:
 - Escaping the summary chooser reopens `/anycopy` with focus restored to the node you tried to select
 - Cancelling the custom summarization editor returns to the summary chooser
 - If no nodes are selected, `Shift+C` copies the focused node
+- Tool-result previews always show the originating tool name and arguments above the result. Copying the node includes both the call and result
+- `Shift+R` anchors a range at the focused node. Tree movement extends or shrinks the inclusive range, toggling every node against its state when the range started
+- Search, filter, and fold changes finish an active range while preserving its selected nodes
+- `Tab` switches directly between the tree-focused and preview-focused layouts. Both panes remain visible according to their configured ratios
+- `?` lists every effective native tree and anycopy binding. It omits native actions that anycopy does not implement
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
@@ -85,12 +93,18 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
 - `treeFilterMode`: initial tree filter mode when opening `/anycopy`; defaults to `default` to match `/tree`
   - one of: `default` | `no-tools` | `user-only` | `labeled-only` | `all`
 - `persistFoldState`: whether `/anycopy` persists folded branches across reopenings and later sessions; defaults to `true`; when disabled, `/anycopy` does not read or write hidden fold-state session entries
-- `keys`: keybindings used inside the `/anycopy` overlay for copy/preview actions and the creation timestamp toggle
+- `layout.treeFocusTreeRatio`: fraction of pane rows used by the tree in tree-focused mode
+- `layout.previewFocusTreeRatio`: fraction of pane rows used by the tree in preview-focused mode
+- `keys`: keybindings used inside the `/anycopy` overlay
 
 ```json
 {
   "treeFilterMode": "default",
   "persistFoldState": true,
+  "layout": {
+    "treeFocusTreeRatio": 0.85,
+    "previewFocusTreeRatio": 0.15
+  },
   "keys": {
     "toggleSelect": "shift+a",
     "copy": "shift+c",
@@ -100,7 +114,10 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
     "scrollUp": "shift+up",
     "scrollDown": "shift+down",
     "pageUp": "shift+pageup",
-    "pageDown": "shift+pagedown"
+    "pageDown": "shift+pagedown",
+    "togglePaneFocus": "tab",
+    "toggleRangeSelection": "shift+r",
+    "help": "?"
   }
 }
 ```

--- a/packages/pi-anycopy/README.md
+++ b/packages/pi-anycopy/README.md
@@ -57,7 +57,7 @@ Defaults (customizable in `config.json`):
 | `Shift+Ctrl+T` | Toggle node creation timestamps |
 | `Shift+Up` / `Shift+Down` | Scroll node preview by line |
 | `Shift+PageUp` / `Shift+PageDown` | Page through node preview |
-| `?` | Show every effective native tree and anycopy action |
+| `?` | Show available anycopy and native tree keybindings |
 | `Esc` | Close |
 
 Notes:
@@ -71,9 +71,9 @@ Notes:
 - `Shift+R` anchors a range at the focused node. Tree movement extends or shrinks the inclusive range and adds every node in that range to the existing selection
 - Search, filter, and fold changes finish an active range while preserving its selected nodes
 - `Tab` switches directly between the tree-focused and preview-focused layouts. Both panes remain visible according to their configured ratios
-- `?` lists every effective native tree and anycopy binding. It omits native actions that anycopy does not implement
-- An optional global shortcut opens anycopy without clearing the editor draft. This copy-only mode keeps `Shift+C` unchanged, while `Enter` explains that navigation requires command-opened `/anycopy`
-- Custom session entries use readable labeled content in previews and clipboard output. Numeric timestamp fields ending in `At` use the local time zone
+- `?` lists the anycopy and native tree keybindings available in the overlay
+- An optional Pi shortcut opens anycopy without clearing the editor draft. This copy-only view keeps `Shift+C` available; use `/anycopy` when you want `Enter` to navigate the session tree
+- Custom session entries use readable labeled content in previews and clipboard output. Timestamps in custom session entries use the local time zone
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
@@ -95,10 +95,10 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
 - `treeFilterMode`: initial tree filter mode when opening `/anycopy`; defaults to `default` to match `/tree`
   - one of: `default` | `no-tools` | `user-only` | `labeled-only` | `all`
 - `persistFoldState`: whether `/anycopy` persists folded branches across reopenings and later sessions; defaults to `true`; when disabled, `/anycopy` does not read or write hidden fold-state session entries
-- `shortcut`: optional global shortcut that opens copy-only anycopy without clearing the current editor draft. Set it to a key such as `ctrl+shift+c`, or leave it as `null`
-- `hints.mode`: `full` shows every inline action, while `compact` keeps one status row with the help and Enter actions
-- `layout.treeFocusTreeRatio`: fraction of pane rows used by the tree in tree-focused mode
-- `layout.previewFocusTreeRatio`: fraction of pane rows used by the tree in preview-focused mode
+- `shortcut`: optional Pi shortcut that opens copy-only anycopy without clearing the current editor draft. Set it to a key such as `ctrl+shift+c`, or leave it as `null`
+- `hints.mode`: `full` displays shortcut hints below the tree, while `compact` uses one status row for help and Enter guidance
+- `layout.treeFocusTreeRatio`: fraction of pane rows used by the tree in tree-focused mode; must be greater than `0` and less than `1`
+- `layout.previewFocusTreeRatio`: fraction of pane rows used by the tree in preview-focused mode; must be greater than `0` and less than `1`
 - `keys`: keybindings used inside the `/anycopy` overlay
 
 ```json

--- a/packages/pi-anycopy/README.md
+++ b/packages/pi-anycopy/README.md
@@ -68,10 +68,12 @@ Notes:
 - Cancelling the custom summarization editor returns to the summary chooser
 - If no nodes are selected, `Shift+C` copies the focused node
 - Tool-result previews always show the originating tool name and arguments above the result. Copying the node includes both the call and result
-- `Shift+R` anchors a range at the focused node. Tree movement extends or shrinks the inclusive range, toggling every node against its state when the range started
+- `Shift+R` anchors a range at the focused node. Tree movement extends or shrinks the inclusive range and adds every node in that range to the existing selection
 - Search, filter, and fold changes finish an active range while preserving its selected nodes
 - `Tab` switches directly between the tree-focused and preview-focused layouts. Both panes remain visible according to their configured ratios
 - `?` lists every effective native tree and anycopy binding. It omits native actions that anycopy does not implement
+- An optional global shortcut opens anycopy without clearing the editor draft. This copy-only mode keeps `Shift+C` unchanged, while `Enter` explains that navigation requires command-opened `/anycopy`
+- Custom session entries use readable labeled content in previews and clipboard output. Numeric timestamp fields ending in `At` use the local time zone
 - Single-node copies use just that node's content; role prefixes like `user:` or `assistant:` are only added when copying 2 or more nodes
 - When copying multiple selected nodes, they are auto-sorted chronologically by position in the session tree, not by selection order
 - `Shift+A`/`Shift+C` multi-select copy behavior is unchanged by navigation support, while plain space remains available for search queries
@@ -93,6 +95,8 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
 - `treeFilterMode`: initial tree filter mode when opening `/anycopy`; defaults to `default` to match `/tree`
   - one of: `default` | `no-tools` | `user-only` | `labeled-only` | `all`
 - `persistFoldState`: whether `/anycopy` persists folded branches across reopenings and later sessions; defaults to `true`; when disabled, `/anycopy` does not read or write hidden fold-state session entries
+- `shortcut`: optional global shortcut that opens copy-only anycopy without clearing the current editor draft. Set it to a key such as `ctrl+shift+c`, or leave it as `null`
+- `hints.mode`: `full` shows every inline action, while `compact` keeps one status row with the help and Enter actions
 - `layout.treeFocusTreeRatio`: fraction of pane rows used by the tree in tree-focused mode
 - `layout.previewFocusTreeRatio`: fraction of pane rows used by the tree in preview-focused mode
 - `keys`: keybindings used inside the `/anycopy` overlay
@@ -101,6 +105,10 @@ Edit `~/.pi/agent/extensions/anycopy/config.json`:
 {
   "treeFilterMode": "default",
   "persistFoldState": true,
+  "shortcut": null,
+  "hints": {
+    "mode": "full"
+  },
   "layout": {
     "treeFocusTreeRatio": 0.85,
     "previewFocusTreeRatio": 0.15

--- a/packages/pi-anycopy/package.json
+++ b/packages/pi-anycopy/package.json
@@ -29,6 +29,7 @@
     "clean": ["extensions/anycopy"],
     "copy": [
       { "from": "../../extensions/anycopy/index.ts", "to": "extensions/anycopy/index.ts" },
+      { "from": "../../extensions/anycopy/custom-entry.ts", "to": "extensions/anycopy/custom-entry.ts" },
       { "from": "../../extensions/anycopy/interaction-state.ts", "to": "extensions/anycopy/interaction-state.ts" },
       { "from": "../../extensions/anycopy/key-help-data.ts", "to": "extensions/anycopy/key-help-data.ts" },
       { "from": "../../extensions/anycopy/key-help.ts", "to": "extensions/anycopy/key-help.ts" },

--- a/packages/pi-anycopy/package.json
+++ b/packages/pi-anycopy/package.json
@@ -28,10 +28,14 @@
   "dot314Prepack": {
     "copy": [
       { "from": "../../extensions/anycopy/index.ts", "to": "extensions/anycopy/index.ts" },
+      { "from": "../../extensions/anycopy/interaction-state.ts", "to": "extensions/anycopy/interaction-state.ts" },
+      { "from": "../../extensions/anycopy/key-help-data.ts", "to": "extensions/anycopy/key-help-data.ts" },
+      { "from": "../../extensions/anycopy/key-help.ts", "to": "extensions/anycopy/key-help.ts" },
       { "from": "../../extensions/anycopy/enter-navigation.ts", "to": "extensions/anycopy/enter-navigation.ts" },
       { "from": "../../extensions/anycopy/fold-state.ts", "to": "extensions/anycopy/fold-state.ts" },
       { "from": "../../extensions/anycopy/preview-window.ts", "to": "extensions/anycopy/preview-window.ts" },
       { "from": "../../extensions/anycopy/timestamps.ts", "to": "extensions/anycopy/timestamps.ts" },
+      { "from": "../../extensions/anycopy/tool-call-copy.ts", "to": "extensions/anycopy/tool-call-copy.ts" },
       { "from": "../../extensions/anycopy/tree-order.ts", "to": "extensions/anycopy/tree-order.ts" },
       { "from": "../../extensions/anycopy/viewport-layout.ts", "to": "extensions/anycopy/viewport-layout.ts" },
       { "from": "../../extensions/anycopy/config.json", "to": "extensions/anycopy/config.json" },

--- a/packages/pi-anycopy/package.json
+++ b/packages/pi-anycopy/package.json
@@ -26,6 +26,7 @@
   },
   "files": ["extensions/**", "README.md", "CHANGELOG.md", "LICENSE", "package.json"],
   "dot314Prepack": {
+    "clean": ["extensions/anycopy"],
     "copy": [
       { "from": "../../extensions/anycopy/index.ts", "to": "extensions/anycopy/index.ts" },
       { "from": "../../extensions/anycopy/interaction-state.ts", "to": "extensions/anycopy/interaction-state.ts" },

--- a/packages/pi-anycopy/package.json
+++ b/packages/pi-anycopy/package.json
@@ -34,6 +34,7 @@
       { "from": "../../extensions/anycopy/enter-navigation.ts", "to": "extensions/anycopy/enter-navigation.ts" },
       { "from": "../../extensions/anycopy/fold-state.ts", "to": "extensions/anycopy/fold-state.ts" },
       { "from": "../../extensions/anycopy/preview-window.ts", "to": "extensions/anycopy/preview-window.ts" },
+      { "from": "../../extensions/anycopy/status-hints.ts", "to": "extensions/anycopy/status-hints.ts" },
       { "from": "../../extensions/anycopy/timestamps.ts", "to": "extensions/anycopy/timestamps.ts" },
       { "from": "../../extensions/anycopy/tool-call-copy.ts", "to": "extensions/anycopy/tool-call-copy.ts" },
       { "from": "../../extensions/anycopy/tree-order.ts", "to": "extensions/anycopy/tree-order.ts" },


### PR DESCRIPTION
## Summary

- Bind inclusive range selection to `Shift+R`.
- Treat each tool result as its call and result together in both preview and clipboard output.
- Toggle directly between tree-focused and preview-focused layouts with `Tab`, while keeping both ratios configurable.
- Show every effective native tree and anycopy action in `?` help, excluding native `Ctrl+X` because it is inactive in anycopy.
- Spell modifier names out in hints.

This version leaves out the structural Markdown picker, `Shift+B`, the external-editor workflow, and the extra tool-copy modes and configuration.

It also reports clipboard failures, bounds large tool arguments in previews, handles deep tool-result parent chains, and cleans package staging before prepack.

## Tests

- `node --test extensions/anycopy/test/*.test.ts`, 53 passed.
- `node --experimental-strip-types --check extensions/anycopy/index.ts`
- `npm pack --dry-run` in `packages/pi-anycopy`

If you want anything else adjusted, just point it out and I'll update the branch.